### PR TITLE
🧹 remove unused methods from PageTransition

### DIFF
--- a/js/page-transition.js
+++ b/js/page-transition.js
@@ -483,14 +483,6 @@ import * as THREE from './vendor/three.module.min.js';
         });
     };
 
-    PageTransition.prototype.setAmbientIntroFlag = function () {};
-
-    PageTransition.prototype.shouldUseAmbientTransition = function () {
-        return false;
-    };
-
-    PageTransition.prototype.triggerAmbientExit = function () {};
-
     PageTransition.prototype.buildTransitionUrl = function (url) {
         try {
             const nextUrl = new window.URL(url, window.location.href);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed unused methods `setAmbientIntroFlag`, `shouldUseAmbientTransition`, and `triggerAmbientExit` from the `PageTransition` prototype in `js/page-transition.js`.

💡 **Why:** How this improves maintainability
These methods were either empty or returned a hardcoded value and were unreferenced anywhere in the codebase. Removing this dead code simplifies the `PageTransition` class and makes it easier to understand its actual functionality.

✅ **Verification:** How you confirmed the change is safe
- Verified with `grep` that the removed methods are not called or referenced anywhere in the repository.
- Ran the project's linter (`eslint`) to ensure no syntax errors or regressions were introduced.
- Confirmed that the `captureAndStoreCurrentScene` method is still present and correctly used in the `navigate` method.

✨ **Result:** The improvement achieved
A cleaner and more maintainable `PageTransition` class with reduced dead code.

---
*PR created automatically by Jules for task [7840835471635839945](https://jules.google.com/task/7840835471635839945) started by @ryusoh*