### PR TITLE
🧪 Testing improvement for clampScrollTop

### DIFF
--- a/js/block-navigation.js
+++ b/js/block-navigation.js
@@ -323,4 +323,12 @@
     }
 
     ready(init);
+
+    // eslint-disable-next-line no-undef
+    if (typeof module !== 'undefined' && module.exports) {
+        // eslint-disable-next-line no-undef
+        module.exports = {
+            clampScrollTop,
+        };
+    }
 })();

--- a/tests/js/block-navigation.test.js
+++ b/tests/js/block-navigation.test.js
@@ -1,0 +1,108 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+/**
+ * Tests for block-navigation.js
+ */
+
+const sourcePath = path.resolve(__dirname, '../../js/block-navigation.js');
+const code = fs.readFileSync(sourcePath, 'utf8');
+
+describe('block-navigation', () => {
+    let clampScrollTop;
+    let context;
+    let mockDocument;
+    let mockWindow;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockDocument = {
+            documentElement: {
+                scrollHeight: 1000,
+            },
+            body: {
+                scrollHeight: 1000,
+            },
+            readyState: 'complete',
+            addEventListener: jest.fn(),
+            createTreeWalker: jest.fn().mockReturnValue({
+                nextNode: jest.fn().mockReturnValue(false),
+            }),
+            activeElement: null,
+            images: [],
+        };
+
+        mockWindow = {
+            innerHeight: 500,
+            scrollY: 0,
+            addEventListener: jest.fn(),
+            scrollTo: jest.fn(),
+            matchMedia: jest.fn().mockReturnValue({ matches: false }),
+        };
+
+        // We provide a module object to capture the exports
+        const mockModule = {
+            exports: {},
+        };
+
+        context = {
+            document: mockDocument,
+            window: mockWindow,
+            module: mockModule,
+            console: console,
+            setTimeout: jest.fn(),
+            clearTimeout: jest.fn(),
+            Set: Set,
+            Array: Array,
+            Math: Math,
+            Number: Number,
+        };
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        clampScrollTop = context.module.exports.clampScrollTop;
+    });
+
+    describe('clampScrollTop', () => {
+        test('should clamp to 0 if value is less than 0', () => {
+            mockDocument.documentElement.scrollHeight = 1000;
+            mockWindow.innerHeight = 500;
+            // maxScroll = 500
+            expect(clampScrollTop(-100)).toBe(0);
+        });
+
+        test('should clamp to maxScroll if value is greater than maxScroll', () => {
+            mockDocument.documentElement.scrollHeight = 1000;
+            mockWindow.innerHeight = 500;
+            // maxScroll = 500
+            expect(clampScrollTop(600)).toBe(500);
+        });
+
+        test('should return value if it is between 0 and maxScroll', () => {
+            mockDocument.documentElement.scrollHeight = 1000;
+            mockWindow.innerHeight = 500;
+            // maxScroll = 500
+            expect(clampScrollTop(250)).toBe(250);
+        });
+
+        test('should clamp to 0 if maxScroll is less than 0', () => {
+            mockDocument.documentElement.scrollHeight = 400;
+            mockWindow.innerHeight = 500;
+            // maxScroll = -100
+            // Since maxScroll < 0, it should return Math.max(0, value)
+            expect(clampScrollTop(200)).toBe(200);
+            expect(clampScrollTop(-50)).toBe(0);
+        });
+
+        test('should clamp to Math.max(0, value) if maxScroll is not finite', () => {
+            mockDocument.documentElement.scrollHeight = NaN;
+            mockWindow.innerHeight = 500;
+            // maxScroll = NaN
+            expect(clampScrollTop(300)).toBe(300);
+            expect(clampScrollTop(-100)).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of test coverage for the `clampScrollTop` helper function located in `js/block-navigation.js`. The function manages scroll limits, which are susceptible to edge conditions such as `NaN` geometry or negative scroll bounds.

📊 **Coverage:** What scenarios are now tested
The new test suite covers:
* Normal clamping where the scroll target is between `0` and `maxScroll`.
* Clamping to `0` when the scroll target is negative.
* Clamping to `maxScroll` when the scroll target exceeds the boundary.
* Correctly handling the edge case where `maxScroll` is negative.
* Correctly handling the edge case where `maxScroll` is not finite (e.g., `NaN`).

✨ **Result:** The improvement in test coverage
The logic that handles edge cases and math boundaries for `clampScrollTop` is fully tested and verified in our `vm` environment mock, preventing regressions for scrolling behavior.

---
*PR created automatically by Jules for task [17776307542226837883](https://jules.google.com/task/17776307542226837883) started by @ryusoh*