### PR TITLE
⚡ Bolt: Native lazy loading for portfolio images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2026-03-11 - Native Lazy Loading on Image Heavy Pages
+
+**Learning:** Found that the portfolio pages (p1/, p2/, p3/) are extremely image-heavy, loading up to ~16MB of images concurrently without native lazy loading on the `<img>` tags. The site relies heavily on a block-navigation component that depends on intersecting viewports, but fetching all these high-res (approx 1MB each) images at once blocks critical bandwidth and parse time.
+**Action:** Always add `loading="lazy"` to below-the-fold `<img ...>` tags to massively defer offscreen image network requests, significantly improving Initial Load Time and reducing unnecessary bandwidth usage.

--- a/p1/index.html
+++ b/p1/index.html
@@ -159,18 +159,22 @@
                                 <img
                                     src="/assets/img/p1/DSCF8974-2.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF0361-2.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF8927-2.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF8961-2.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
 
                                 <p>Far from the world of you and I</p>
@@ -178,18 +182,22 @@
                                 <img
                                     src="/assets/img/p1/DSCF7141.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/R0002885-2.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF2432-2.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF6943.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
 
                                 <p>God save us everyone</p>
@@ -198,18 +206,22 @@
                                 <img
                                     src="/assets/img/p1/DSCF2441-3.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF1157.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF5423-5.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF1093.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
 
                                 <p>When I close my eyes tonight</p>
@@ -217,18 +229,22 @@
                                 <img
                                     src="/assets/img/p1/286FC1B3-5576-440B-8718-2E872C98E713.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF5891-9.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF5903-2.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p1/DSCF4402-8.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
 
                                 <p>Lift me up, let me go</p>
@@ -236,6 +252,7 @@
                                 <img
                                     src="/assets/img/p1/DSCF5916-4.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                             </div>
                         </div>

--- a/p2/index.html
+++ b/p2/index.html
@@ -183,66 +183,82 @@
                                 <img
                                     src="/assets/img/p2/R0002358.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF5163-8.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF8593-3.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF8402-3.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF8444-3.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF3433.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/A20E2E39-AF83-4FD0-A6F7-3D2243A753DC.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF0883-3.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF7203-9.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF8772.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF3495-2.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF8739.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF3487-3.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF3445-2.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/R0004664.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p2/DSCF2862-3.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                             </div>
                         </div>

--- a/p3/index.html
+++ b/p3/index.html
@@ -162,62 +162,77 @@
                                 <img
                                     src="/assets/img/p3/DSCF7728.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF7753-3.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF7186-2.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF6946.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/8B0245DC-4C12-4CD1-A6B0-96883BFAF25B.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF5338.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF0490.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF4237-2.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/B5B35521-9A08-4B1C-AAB3-429D75A3769E.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF8563-5.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF3632.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF1137.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF3579.JPG"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF7318-3.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                                 <img
                                     src="/assets/img/p3/DSCF5759-5.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
 
                                 <hr />
@@ -226,6 +241,7 @@
                                 <img
                                     src="/assets/img/p3/DSCF5719-3.jpg"
                                     alt="Street photography by Zhuang Liu"
+                                    loading="lazy"
                                 />
                             </div>
                         </div>


### PR DESCRIPTION
💡 What: Added native `loading="lazy"` to all image tags below the fold across the `p1`, `p2`, and `p3` portfolio pages.
🎯 Why: The portfolio pages load a high volume of images simultaneously (roughly 15-18 images per page at ~1MB each). Without lazy loading, the browser fetches all 15+ MBs concurrently on page load. This blocks the main thread, wastes critical bandwidth for users who don't scroll all the way down, and increases Time to Interactive and Largest Contentful Paint metrics.
📊 Impact: Expected to reduce initial page payload by ~90% (only fetching the first image and placeholder areas immediately) and improve Time to Interactive significantly on image-heavy pages.
🔬 Measurement: Verify network requests in DevTools (only the first image should load immediately). Scrolling down the page will sequentially trigger network requests for the remaining lazy-loaded images.

---
*PR created automatically by Jules for task [14757298183021821071](https://jules.google.com/task/14757298183021821071) started by @ryusoh*