### PR TITLE
🎨 Palette: Add ARIA labels to icon-only back buttons

### DIFF
--- a/p1/index.html
+++ b/p1/index.html
@@ -117,13 +117,8 @@
                     z-index: 1000;
                 }
             </style>
-            <a
-                class="nav-back"
-                href="../"
-                target="_self"
-                data-page-transition
-                data-destination="home"
-            >
+            <!-- prettier-ignore -->
+            <a class="nav-back" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
                 <i class="fa fa-chevron-left"></i>
             </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -117,13 +117,8 @@
                     z-index: 1000;
                 }
             </style>
-            <a
-                class="nav-back"
-                href="../"
-                target="_self"
-                data-page-transition
-                data-destination="home"
-            >
+            <!-- prettier-ignore -->
+            <a class="nav-back" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
                 <i class="fa fa-chevron-left"></i>
             </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -111,13 +111,8 @@
                     z-index: 1000;
                 }
             </style>
-            <a
-                class="nav-back"
-                href="../"
-                target="_self"
-                data-page-transition
-                data-destination="home"
-            >
+            <!-- prettier-ignore -->
+            <a class="nav-back" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
                 <i class="fa fa-chevron-left"></i>
             </a>
 


### PR DESCRIPTION
💡 **What:** Added `aria-label="Back to home"` to the `.nav-back` anchor links across all project pages (`p1`, `p2`, `p3`).

🎯 **Why:** The back buttons on project pages were implemented as anchor tags containing only a FontAwesome icon (`<i class="fa fa-chevron-left"></i>`). Because there was no visible text or ARIA label, screen readers and assistive technologies could not announce the purpose of these links to users, resulting in poor accessibility and a violation of standard WCAG guidelines for interactive elements.

📸 **Before/After:** No visual changes.

♿ **Accessibility:** Screen readers will now announce "Back to home" when focusing on the back buttons on project pages.

---
*PR created automatically by Jules for task [15173892846292557174](https://jules.google.com/task/15173892846292557174) started by @ryusoh*