### PR TITLE
🎨 Palette: Add global focus-visible styles for keyboard accessibility

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -441,3 +441,11 @@ footer {
     --page-transition-primary: rgba(206, 35, 35, 0.55);
     --page-transition-secondary: rgba(206, 35, 35, 0.3);
 }
+
+/* Global focus-visible for accessibility */
+:focus-visible {
+    outline: 2px solid rgba(206, 35, 35, 0.8) !important;
+    outline-offset: 4px;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
+    border-radius: 2px;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1087,3 +1087,11 @@ td {
         opacity: 1;
     }
 }
+
+/* Global focus-visible for accessibility */
+:focus-visible {
+    outline: 2px solid rgba(206, 35, 35, 0.8) !important;
+    outline-offset: 4px;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
+    border-radius: 2px;
+}


### PR DESCRIPTION
### 💡 What:
Added a global `:focus-visible` CSS rule to `main_style.css` and `style.css`.

### 🎯 Why:
To dramatically improve keyboard accessibility across the site. Currently, focus styles are either explicitly set to `outline: none` or not noticeably defined on many elements. This change ensures that any interactive element navigated to via the keyboard receives a clear, high-contrast focus ring (using the existing `--page-transition-primary` accent color alongside a high-contrast white box-shadow for visibility on both dark and light backgrounds).

### ♿ Accessibility:
Provides a clear visual indicator for keyboard navigation across the entire portfolio and homepage. Using `:focus-visible` ensures that this outline only appears when navigating with a keyboard, preventing an unwanted focus ring when clicking elements with a mouse, thus preserving the visual design while enhancing a11y.

---
*PR created automatically by Jules for task [8640990375888152479](https://jules.google.com/task/8640990375888152479) started by @ryusoh*