### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix malicious URL scheme navigation

### DIFF
--- a/js/page-transition.js
+++ b/js/page-transition.js
@@ -647,10 +647,17 @@ import * as THREE from './vendor/three.module.min.js';
     };
 
     PageTransition.prototype.navigate = function (url) {
-        if (typeof url === 'string' && url.trim().toLowerCase().startsWith('javascript:')) {
-            // eslint-disable-next-line no-console
-            console.error('[page-transition] Blocked potentially malicious javascript: URL');
-            return;
+        if (typeof url === 'string') {
+            const normalizedUrl = url.trim().toLowerCase();
+            if (
+                normalizedUrl.startsWith('javascript:') ||
+                normalizedUrl.startsWith('data:') ||
+                normalizedUrl.startsWith('vbscript:')
+            ) {
+                // eslint-disable-next-line no-console
+                console.error('[page-transition] Blocked potentially malicious URL scheme');
+                return;
+            }
         }
         if (!this.enabled || this.isAnimating) {
             window.location.assign(url);

--- a/tests/js/security.test.js
+++ b/tests/js/security.test.js
@@ -113,16 +113,21 @@ describe('DOM XSS Security Tests', () => {
         jest.clearAllTimers();
     });
 
-    test('PageTransition.navigate should block javascript: URLs', () => {
+    test('PageTransition.navigate should block malicious URL schemes', () => {
         const PageTransition = context.window.__PageTransitionForTesting._Constructor;
         const pt = new PageTransition();
 
         pt.navigate('javascript:alert(1)');
-
         expect(context.window.location.assign).not.toHaveBeenCalled();
         expect(context.console.error).toHaveBeenCalledWith(
-            expect.stringContaining('Blocked potentially malicious javascript: URL')
+            expect.stringContaining('Blocked potentially malicious URL scheme')
         );
+
+        pt.navigate('data:text/html,<script>alert(1)</script>');
+        expect(context.window.location.assign).not.toHaveBeenCalled();
+
+        pt.navigate('vbscript:msgbox(1)');
+        expect(context.window.location.assign).not.toHaveBeenCalled();
     });
 
     test('PageTransition.navigate should allow valid same-origin URLs', () => {


### PR DESCRIPTION
This PR enhances the security of the `PageTransition` module by preventing potential DOM-based Cross-Site Scripting (XSS) attacks. Specifically, the `navigate` function has been updated to explicitly block `data:` and `vbscript:` URL schemes, in addition to the existing check for `javascript:` URIs, before passing URLs to `window.location.assign()`. The corresponding test suite has been updated to verify these protections.

---
*PR created automatically by Jules for task [17107973923518175878](https://jules.google.com/task/17107973923518175878) started by @ryusoh*