### PR TITLE
⚡ Bolt: Prevent layout thrashing in Font Awesome loader

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,9 @@
 **Learning:** Found that `debounce` functions used for scroll and resize handlers (`syncCurrentIndex`, `updatePositions`) were relying solely on `setTimeout`. This causes the callback (which often involves synchronous DOM reads like `getBoundingClientRect`) to fire out-of-sync with the browser's render cycle, leading to layout thrashing.
 
 **Action:** Always wrap the final delayed execution of UI-bound debounced functions in `requestAnimationFrame`. This guarantees that heavy layout recalculations happen immediately before the frame is painted, improving performance and predictability on heavy pages.
+
+## 2026-03-13 - Layout Thrashing in Polling Loaders
+
+**Learning:** Found that the `FontAwesomeLoader` in `js/font-awesome-loader.js` was causing significant layout thrashing. It polled for font load completion every 100ms by dynamically creating an `<i>` element, appending it to the DOM, reading its computed style (forcing a synchronous layout/reflow), and then removing it.
+
+**Action:** To prevent layout thrashing during repeated DOM-based state checks, always prefer reusing a persistent hidden element instead of appending and removing temporary elements on every interval tick.

--- a/js/font-awesome-loader.js
+++ b/js/font-awesome-loader.js
@@ -9,6 +9,7 @@ class FontAwesomeLoader {
         this.maxRetries = 10; // Maximum number of checks
         this.retryCount = 0;
         this.faIcons = []; // Cache for Font Awesome icon elements
+        this.testElement = null;
     }
 
     /**
@@ -22,6 +23,7 @@ class FontAwesomeLoader {
         if (this.isFontAwesomeLoaded()) {
             this.fontAwesomeLoaded = true;
             this.showIcons();
+            this.cleanupTestElement();
             return;
         }
 
@@ -37,12 +39,17 @@ class FontAwesomeLoader {
      * Check if Font Awesome is loaded by looking for the presence of FA classes
      */
     isFontAwesomeLoaded() {
-        // Create a temporary element to test if FA is loaded
-        const testElement = document.createElement('i');
-        testElement.className = 'fa fa-heart';
-        document.body.appendChild(testElement);
+        // Create a persistent hidden element to test if FA is loaded without layout thrashing
+        if (!this.testElement) {
+            this.testElement = document.createElement('i');
+            this.testElement.className = 'fa fa-heart';
+            this.testElement.setAttribute('aria-hidden', 'true');
+            this.testElement.style.cssText =
+                'visibility: hidden; position: absolute; top: -9999px; left: -9999px;';
+            document.body.appendChild(this.testElement);
+        }
 
-        const computedStyle = window.getComputedStyle(testElement, ':before');
+        const computedStyle = window.getComputedStyle(this.testElement, ':before');
         const hasContent = !!(
             computedStyle &&
             computedStyle.content &&
@@ -50,7 +57,6 @@ class FontAwesomeLoader {
             computedStyle.content !== '""'
         );
 
-        document.body.removeChild(testElement);
         return hasContent;
     }
 
@@ -103,6 +109,17 @@ class FontAwesomeLoader {
         if (this.checkInterval) {
             clearInterval(this.checkInterval);
             this.checkInterval = null;
+        }
+        this.cleanupTestElement();
+    }
+
+    /**
+     * Remove the test element from the DOM
+     */
+    cleanupTestElement() {
+        if (this.testElement && this.testElement.parentNode) {
+            this.testElement.parentNode.removeChild(this.testElement);
+            this.testElement = null;
         }
     }
 

--- a/tests/js/font-awesome-loader.test.js
+++ b/tests/js/font-awesome-loader.test.js
@@ -240,7 +240,7 @@ describe('FontAwesomeLoader', () => {
     });
 
     test('isFontAwesomeLoaded should return true if FA content is present', () => {
-        const mockElement = { className: '', style: {} };
+        const mockElement = { className: '', style: {}, setAttribute: jest.fn() };
         context.document.createElement.mockReturnValue(mockElement);
         context.window.getComputedStyle.mockReturnValue({
             content: '"\\f004"',
@@ -250,14 +250,18 @@ describe('FontAwesomeLoader', () => {
 
         expect(context.document.createElement).toHaveBeenCalledWith('i');
         expect(mockElement.className).toBe('fa fa-heart');
+        expect(mockElement.setAttribute).toHaveBeenCalledWith('aria-hidden', 'true');
+        expect(mockElement.style.cssText).toBe(
+            'visibility: hidden; position: absolute; top: -9999px; left: -9999px;'
+        );
         expect(context.document.body.appendChild).toHaveBeenCalledWith(mockElement);
         expect(context.window.getComputedStyle).toHaveBeenCalledWith(mockElement, ':before');
-        expect(context.document.body.removeChild).toHaveBeenCalledWith(mockElement);
         expect(result).toBe(true);
     });
 
     test('isFontAwesomeLoaded should return false if FA content is not present', () => {
-        const mockElement = { className: '', style: {} };
+        loader.testElement = null; // Reset
+        const mockElement = { className: '', style: {}, setAttribute: jest.fn() };
         context.document.createElement.mockReturnValue(mockElement);
 
         // Mock non-existent content
@@ -280,7 +284,8 @@ describe('FontAwesomeLoader', () => {
     });
 
     test('isFontAwesomeLoaded should return false if computedStyle is null or undefined', () => {
-        const mockElement = { className: '', style: {} };
+        loader.testElement = null; // Reset
+        const mockElement = { className: '', style: {}, setAttribute: jest.fn() };
         context.document.createElement.mockReturnValue(mockElement);
 
         // When window.getComputedStyle returns null (e.g. element is disconnected or in old browsers/edge cases)


### PR DESCRIPTION
💡 **What**:
Updated `FontAwesomeLoader` to reuse a single persistent hidden element (`this.testElement`) instead of creating, appending, and removing a temporary element (`<i>`) on every 100ms polling tick. The persistent element uses CSS `visibility: hidden; position: absolute; top: -9999px; left: -9999px;` to remain fully hidden and detached from the visual layout flow, and includes `aria-hidden="true"` for accessibility. Added `cleanupTestElement()` to properly remove it from the DOM once Font Awesome finishes loading (or timing out).

🎯 **Why**:
The original polling mechanism called `window.getComputedStyle(testElement, ':before')` immediately after appending the temporary element. Because this happened in a 100ms interval loop, it forced the browser to synchronously recalculate layout and styles multiple times per second, leading to layout thrashing, main thread blocking, and increased CPU load during the critical page initialization phase. By reusing a persistent element, the browser can return cached styles for subsequent calls until the font actually loads and invalidates them.

📊 **Impact**:
Eliminates repeated DOM insertions/deletions and forced synchronous layouts every 100ms during the Font Awesome loading phase, noticeably reducing main-thread blocking time and jitter on initial page load.

🔬 **Measurement**:
Verified locally that the persistent test element behaves exactly as the temporary one did, properly detecting when `getComputedStyle` resolves the `content` property to `"\f004"`. Ran full `make check` and Jest test suite successfully (tests updated to mock new `setAttribute` call). Verified via a Playwright UI script that the `fa-heart` test element is correctly injected and subsequently cleaned up without disrupting page layout.

---
*PR created automatically by Jules for task [10110797488103993777](https://jules.google.com/task/10110797488103993777) started by @ryusoh*