### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM XSS bypass via URL control characters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2026-03-13 - [DOM XSS Bypass via URL Control Characters]
+
+**Vulnerability:** The `PageTransition.prototype.navigate` function was vulnerable to a DOM XSS bypass. It relied on `String.prototype.trim()` to sanitize URLs before checking for malicious schemes like `javascript:`.
+**Learning:** `trim()` only removes standard whitespace. Browsers ignore various control characters (e.g., `\x01` to `\x1F`) at the beginning of a URL when evaluating the scheme. An attacker could bypass the `.startsWith('javascript:')` check by prepending a control character (e.g., `\x01javascript:alert(1)`), which would then be executed by `window.location.assign()`.
+**Prevention:** Always use robust normalization, such as a regular expression `url.replace(/^[\s\u0000-\u001F]+/g, '')`, to strip both whitespace and control characters before validating URL schemes to prevent XSS.

--- a/js/page-transition.js
+++ b/js/page-transition.js
@@ -648,7 +648,7 @@ import * as THREE from './vendor/three.module.min.js';
 
     PageTransition.prototype.navigate = function (url) {
         if (typeof url === 'string') {
-            const normalizedUrl = url.trim().toLowerCase();
+            const normalizedUrl = url.replace(/^[\s\u0000-\u001F]+/g, '').toLowerCase();
             if (
                 normalizedUrl.startsWith('javascript:') ||
                 normalizedUrl.startsWith('data:') ||

--- a/tests/js/security.test.js
+++ b/tests/js/security.test.js
@@ -152,6 +152,18 @@ describe('DOM XSS Security Tests', () => {
         expect(context.window.location.assign).not.toHaveBeenCalled();
         expect(context.console.error).toHaveBeenCalled();
     });
+
+    test('PageTransition should block javascript: URLs even with leading control characters', () => {
+        const PageTransition = context.window.__PageTransitionForTesting._Constructor;
+        const pt = new PageTransition();
+
+        pt.navigate('\x01\x02\x09\x1fjavascript:alert(1)');
+
+        expect(context.window.location.assign).not.toHaveBeenCalled();
+        expect(context.console.error).toHaveBeenCalledWith(
+            expect.stringContaining('Blocked potentially malicious URL scheme')
+        );
+    });
 });
 
 // --- Security: target="_blank" links Tests ---


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix DOM XSS bypass via URL control characters

🚨 Severity: HIGH
💡 Vulnerability: The `PageTransition.prototype.navigate` function relied on `String.prototype.trim()` to sanitize URLs before checking for malicious schemes. However, browsers ignore various control characters (e.g., `\x01` to `\x1F`) at the beginning of a URL when evaluating the scheme. An attacker could bypass the `.startsWith('javascript:')` check by prepending a control character (e.g., `\x01javascript:alert(1)`).
🎯 Impact: This DOM XSS vulnerability could allow an attacker to execute arbitrary JavaScript in the context of the user's session if they can control the URL passed to the `navigate` function.
🔧 Fix: Updated the URL normalization logic to use a regular expression (`/^[\s\u0000-\u001F]+/g`) that strips both standard whitespace and control characters before validating the URL scheme.
✅ Verification: Added a unit test in `tests/js/security.test.js` to ensure that URLs with leading control characters are correctly identified as malicious and blocked. Ran all Jest tests successfully.

---
*PR created automatically by Jules for task [1246146083389294502](https://jules.google.com/task/1246146083389294502) started by @ryusoh*