### PR TITLE
test: add test coverage for missing utility scripts

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Node VM Environment Mocking for Frontend Utility Scripts
 
 **Learning:** Testing unexported vanilla JS utilities (e.g., `preloader.js`, `service-worker-register.js`, `ga.js`) requires reading the raw source with `fs.readFileSync` and evaluating it inside a custom `vm.runInContext`. When the script has synchronous side effects on load (such as attaching `DOMContentLoaded` event listeners that may crash or create unwanted behavior in the test runner), these strings must be stripped from the source code using regex before `vm.runInContext` evaluation.
+
+## 2025-03-01 - Testing window fallback structures
+
+**Learning:** When testing scripts that attach themselves globally like `window.AMBIENT_CONFIG = Object.assign({...}, window.AMBIENT_CONFIG)`, one must ensure the context provides a valid `Object` constructor and an empty initial `window` object to prevent `ReferenceError`s and allow successful assignment in the Node `vm` context.

--- a/tests/js/ambient/config/default.test.js
+++ b/tests/js/ambient/config/default.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('ambient/config/default.js', () => {
+    let context;
+    let code;
+
+    beforeEach(() => {
+        code = fs.readFileSync(
+            path.resolve(__dirname, '../../../../js/ambient/config/default.js'),
+            'utf8'
+        );
+
+        context = {
+            window: {},
+            Object: Object,
+        };
+    });
+
+    test('sets default configuration on window.AMBIENT_CONFIG', () => {
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(context.window.AMBIENT_CONFIG).toBeDefined();
+        expect(context.window.AMBIENT_CONFIG.enabled).toBe(true);
+        expect(context.window.AMBIENT_CONFIG.minWidth).toBe(0);
+        expect(context.window.AMBIENT_CONFIG.maxParticles).toBe(300);
+        expect(context.window.AMBIENT_CONFIG.densityDivisor).toBe(20000);
+        expect(context.window.AMBIENT_CONFIG.radius).toEqual({ min: 1.0, max: 8.0 });
+        expect(context.window.AMBIENT_CONFIG.alpha).toEqual({ min: 0.1, max: 0.6 });
+        expect(context.window.AMBIENT_CONFIG.speed).toBe(0.6);
+        expect(context.window.AMBIENT_CONFIG.zIndex).toBe(1);
+        expect(context.window.AMBIENT_CONFIG.blend).toBe('screen');
+        expect(context.window.AMBIENT_CONFIG.respectReducedMotion).toBe(false);
+    });
+
+    test('merges with existing window.AMBIENT_CONFIG', () => {
+        context.window.AMBIENT_CONFIG = {
+            maxParticles: 500,
+            speed: 1.5,
+        };
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(context.window.AMBIENT_CONFIG.maxParticles).toBe(500);
+        expect(context.window.AMBIENT_CONFIG.speed).toBe(1.5);
+        expect(context.window.AMBIENT_CONFIG.enabled).toBe(true);
+    });
+
+    test('handles errors gracefully without throwing', () => {
+        context.window = null; // This will cause an error when assigning
+
+        expect(() => {
+            vm.createContext(context);
+            vm.runInContext(code, context);
+        }).not.toThrow();
+    });
+});

--- a/tests/js/ambient/loader.test.js
+++ b/tests/js/ambient/loader.test.js
@@ -1,0 +1,113 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('ambient/loader.js', () => {
+    let context;
+    let code;
+    let mockCDNLoader;
+    let mockDocument;
+    let mockBody;
+
+    beforeEach(() => {
+        code = fs.readFileSync(path.resolve(__dirname, '../../../js/ambient/loader.js'), 'utf8');
+
+        mockCDNLoader = {
+            loadScriptSequential: jest.fn().mockResolvedValue(),
+            loadCssWithFallback: jest.fn().mockResolvedValue(),
+        };
+
+        mockBody = {
+            getAttribute: jest.fn().mockReturnValue('home'),
+        };
+
+        mockDocument = {
+            body: mockBody,
+        };
+
+        context = {
+            window: {
+                CDNLoader: mockCDNLoader,
+                innerWidth: 1200,
+                matchMedia: jest.fn().mockReturnValue({ matches: false }),
+                Promise: Promise,
+            },
+            document: mockDocument,
+        };
+    });
+
+    test('exits early if prefers-reduced-motion is true', () => {
+        context.window.matchMedia.mockReturnValue({ matches: true });
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockCDNLoader.loadCssWithFallback).not.toHaveBeenCalled();
+    });
+
+    test('exits early if window innerWidth is less than 1024', () => {
+        context.window.innerWidth = 800;
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockCDNLoader.loadCssWithFallback).not.toHaveBeenCalled();
+    });
+
+    test('exits early if window.CDNLoader is missing', () => {
+        delete context.window.CDNLoader;
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockCDNLoader.loadCssWithFallback).not.toHaveBeenCalled();
+    });
+
+    test('loads ambient CSS and legacy scripts correctly', async () => {
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockCDNLoader.loadCssWithFallback).toHaveBeenCalledWith([
+            '/css/ambient/ambient.css',
+        ]);
+
+        await new Promise(process.nextTick);
+        await new Promise(process.nextTick);
+        await new Promise(process.nextTick);
+
+        expect(mockCDNLoader.loadScriptSequential).toHaveBeenCalledWith(['/js/vendor/sketch.js']);
+    });
+
+    test('loads quantum particles when pageType is home or project', async () => {
+        mockBody.getAttribute.mockReturnValue('home');
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        await new Promise(process.nextTick);
+        await new Promise(process.nextTick);
+        await new Promise(process.nextTick);
+
+        expect(mockCDNLoader.loadScriptSequential).toHaveBeenCalledWith(
+            ['/js/ambient/quantum_particles.js'],
+            { defer: true }
+        );
+    });
+
+    test('does not load quantum particles for other page types', async () => {
+        mockBody.getAttribute.mockReturnValue('about');
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        await new Promise(process.nextTick);
+        await new Promise(process.nextTick);
+        await new Promise(process.nextTick);
+
+        const calls = mockCDNLoader.loadScriptSequential.mock.calls;
+        const loadedQuantum = calls.some((call) =>
+            call[0].includes('/js/ambient/quantum_particles.js')
+        );
+        expect(loadedQuantum).toBe(false);
+    });
+});

--- a/tests/js/loader/vendorLoader.test.js
+++ b/tests/js/loader/vendorLoader.test.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('loader/vendorLoader.js', () => {
+    let context;
+    let code;
+    let mockCDNLoader;
+
+    beforeEach(() => {
+        code = fs.readFileSync(
+            path.resolve(__dirname, '../../../js/loader/vendorLoader.js'),
+            'utf8'
+        );
+
+        mockCDNLoader = {
+            preconnect: jest.fn(),
+            loadCssWithFallback: jest.fn(),
+        };
+
+        context = {
+            window: {
+                CDNLoader: mockCDNLoader,
+            },
+        };
+    });
+
+    test('exits early if window.CDNLoader is missing', () => {
+        delete context.window.CDNLoader;
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockCDNLoader.preconnect).not.toHaveBeenCalled();
+    });
+
+    test('preconnects to required font domains', () => {
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockCDNLoader.preconnect).toHaveBeenCalledWith([
+            'https://fonts.googleapis.com',
+            'https://fonts.gstatic.com',
+            'https://fonts.bunny.net',
+        ]);
+    });
+
+    test('loads font awesome CSS with fallback', () => {
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockCDNLoader.loadCssWithFallback).toHaveBeenCalledWith([
+            '/assets/vendor/font-awesome/css/font-awesome.min.css',
+        ]);
+    });
+
+    test('loads google fonts with fallback', () => {
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockCDNLoader.loadCssWithFallback).toHaveBeenCalledWith([
+            'https://fonts.googleapis.com/css2?family=Lobster&display=swap',
+            'https://fonts.bunny.net/css?family=Lobster',
+        ]);
+    });
+
+    test('handles errors gracefully without throwing', () => {
+        mockCDNLoader.preconnect.mockImplementation(() => {
+            throw new Error('Preconnect failed');
+        });
+
+        expect(() => {
+            vm.createContext(context);
+            vm.runInContext(code, context);
+        }).not.toThrow();
+    });
+});


### PR DESCRIPTION
Identifies 3 utility scripts without proper test coverage (`js/ambient/loader.js`, `js/loader/vendorLoader.js`, and `js/ambient/config/default.js`) and implements unit tests for them using Jest and Node's `vm` module to maintain proper isolation and handle side-effects. Logs learning on Node `vm` context setup to the `.jules/testpilot.md` file.

---
*PR created automatically by Jules for task [5585012451744503931](https://jules.google.com/task/5585012451744503931) started by @ryusoh*