### PR TITLE
Palette: Add role="presentation" to layout table in index.html

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,8 @@
 
 **Learning:** When using icon-only buttons, providing an `aria-label` on the anchor tag is crucial for screen reader users. However, if the icon itself is implemented via a font (like FontAwesome `<i class="fa..."></i>`), screen readers may attempt to read the icon element redundantly or confusingly. While adding native visual `title` attributes can provide parity for sighted users, it often conflicts with strict minimalist design requirements.
 **Action:** Always add `aria-hidden="true"` to purely visual decorative child elements (like FontAwesome `<i>` tags) inside labeled interactive elements. This ensures screen readers only announce the intended `aria-label` on the parent, improving the non-visual UX without compromising minimalist aesthetic constraints that prohibit visible hover tooltips.
+
+## 2024-05-20 - [Accessibility: Screen Reader Clarity vs Layout Tables]
+
+**Learning:** Using an HTML `<table>` element purely for layout purposes (such as aligning navigation links alongside a category label) will cause screen readers to announce it as a data table with rows and columns, creating a confusing and verbose experience for non-visual users.
+**Action:** Always add `role="presentation"` (or `role="none"`) to layout tables. This strips away the table semantics so that assistive technologies treat the contents as normal layout elements, significantly improving the non-visual user experience without altering the visual structure or relying on new CSS layouts.

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
                         </a>
                     </span>
                 </p>
-                <table id="nav">
+                <table id="nav" role="presentation">
                     <tbody>
                         <tr>
                             <td class="portfolio-category" rowspan="3">Portfolio</td>


### PR DESCRIPTION
💡 What: Added `role="presentation"` to the `<table id="nav">` in `index.html`.
🎯 Why: The table is used exclusively for layout (aligning the "Portfolio" label next to the project links). Without this role, screen readers announce it as a data table (e.g., "Table with 3 rows and 2 columns"), which is verbose and confusing for non-visual users.
📸 Before/After: No visual changes.
♿ Accessibility: Strips semantic table roles from the layout element, dramatically improving the screen reader navigation experience on the homepage. Recorded the learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [9074406064824675006](https://jules.google.com/task/9074406064824675006) started by @ryusoh*