### PR TITLE
ci: add renovatebot configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended"],
+    "labels": ["dependencies"],
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["patch", "pin", "digest"],
+            "automerge": true
+        }
+    ],
+    "pre-commit": {
+        "enabled": true
+    }
+}


### PR DESCRIPTION
Integrates Renovatebot configuration to automate dependency updates across `package.json`, GitHub Actions, and `pre-commit` hooks.

It follows the preferences specified:
1. Resides in `.github/renovate.json`.
2. Extends the industry-standard `config:recommended` ruleset.
3. Explicitly manages `pre-commit` (and inherently handles GitHub Actions).
4. Includes a `packageRule` to blindly automerge non-breaking changes (`patch`, `pin`, `digest`).
5. Uses standard labels (`dependencies`).

---
*PR created automatically by Jules for task [17156446142880486439](https://jules.google.com/task/17156446142880486439) started by @ryusoh*