### PR TITLE
🧪 Add unit tests for AssetPreloader.getCurrentPageKey

### DIFF
--- a/js/preloader.js
+++ b/js/preloader.js
@@ -163,3 +163,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const preloader = new AssetPreloader();
     preloader.init();
 });
+
+// eslint-disable-next-line no-undef
+if (typeof module !== 'undefined' && module.exports) {
+    // eslint-disable-next-line no-undef
+    module.exports = {
+        AssetPreloader,
+    };
+}

--- a/tests/js/preloader.test.js
+++ b/tests/js/preloader.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tests for preloader.js
+ */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const sourcePath = path.resolve(__dirname, '../../js/preloader.js');
+const code = fs.readFileSync(sourcePath, 'utf8');
+
+describe('AssetPreloader', () => {
+    let context;
+    let mockDocument;
+    let mockWindow;
+    let AssetPreloader;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockDocument = {
+            createElement: jest.fn().mockReturnValue({}),
+            head: {
+                appendChild: jest.fn(),
+            },
+            addEventListener: jest.fn(),
+        };
+
+        mockWindow = {
+            location: {
+                pathname: '/',
+            },
+            addEventListener: jest.fn(),
+        };
+
+        context = {
+            document: mockDocument,
+            window: mockWindow,
+            navigator: {
+                serviceWorker: {},
+            },
+            console: console,
+            // To capture the class
+            AssetPreloader: undefined,
+        };
+
+        // Capture module.exports
+        const mockModule = { exports: {} };
+        context.module = mockModule;
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        AssetPreloader = mockModule.exports.AssetPreloader;
+    });
+
+    describe('getCurrentPageKey', () => {
+        it('should return "p1" when pathname contains "/p1/"', () => {
+            mockWindow.location.pathname = '/p1/';
+            const preloader = new AssetPreloader();
+            expect(preloader.getCurrentPageKey()).toBe('p1');
+
+            mockWindow.location.pathname = '/project/p1/index.html';
+            expect(preloader.getCurrentPageKey()).toBe('p1');
+        });
+
+        it('should return "p2" when pathname contains "/p2/"', () => {
+            mockWindow.location.pathname = '/p2/';
+            const preloader = new AssetPreloader();
+            expect(preloader.getCurrentPageKey()).toBe('p2');
+
+            mockWindow.location.pathname = '/p2/gallery.html';
+            expect(preloader.getCurrentPageKey()).toBe('p2');
+        });
+
+        it('should return "p3" when pathname contains "/p3/"', () => {
+            mockWindow.location.pathname = '/p3/';
+            const preloader = new AssetPreloader();
+            expect(preloader.getCurrentPageKey()).toBe('p3');
+        });
+
+        it('should return "main" when pathname is "/"', () => {
+            mockWindow.location.pathname = '/';
+            const preloader = new AssetPreloader();
+            expect(preloader.getCurrentPageKey()).toBe('main');
+        });
+
+        it('should return "main" when pathname contains "/index.html"', () => {
+            mockWindow.location.pathname = '/index.html';
+            const preloader = new AssetPreloader();
+            expect(preloader.getCurrentPageKey()).toBe('main');
+
+            mockWindow.location.pathname = '/subdir/index.html';
+            expect(preloader.getCurrentPageKey()).toBe('main');
+        });
+
+        it('should return "main" for unknown paths', () => {
+            mockWindow.location.pathname = '/about.html';
+            const preloader = new AssetPreloader();
+            expect(preloader.getCurrentPageKey()).toBe('main');
+        });
+    });
+});


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `getCurrentPageKey` function in `js/preloader.js` to improve reliability and coverage. It also slightly modifies `js/preloader.js` to export the class for testing in a Node environment while maintaining browser compatibility.

🎯 **What:** The testing gap for `getCurrentPageKey` in `js/preloader.js`.
📊 **Coverage:** 6 scenarios now tested:
- Path containing /p1/ returns 'p1'.
- Path containing /p2/ returns 'p2'.
- Path containing /p3/ returns 'p3'.
- Root path '/' returns 'main'.
- Path containing '/index.html' returns 'main'.
- Unknown paths return 'main'.
✨ **Result:** Improved test coverage for asset preloading logic.

---
*PR created automatically by Jules for task [15008061594752399785](https://jules.google.com/task/15008061594752399785) started by @ryusoh*