### PR TITLE
🧹 log errors in CDNLoader preconnect

### DIFF
--- a/js/loader/cdnFallback.js
+++ b/js/loader/cdnFallback.js
@@ -14,7 +14,10 @@
                 fragment.appendChild(l);
             }
             document.head.appendChild(fragment);
-        } catch {}
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error('Preconnect failed:', e);
+        }
     }
     function loadScriptSequential(urls, attrs) {
         return new Promise(function (resolve, reject) {

--- a/tests/js/loader/cdnFallback.test.js
+++ b/tests/js/loader/cdnFallback.test.js
@@ -47,7 +47,11 @@ describe('CDNLoader', () => {
             document: mockDocument,
             window: mockWindow,
             fetch: jest.fn(),
-            console: console,
+            console: {
+                error: jest.fn(),
+                warn: jest.fn(),
+                log: jest.fn(),
+            },
             setTimeout: setTimeout,
             Promise: Promise,
         };
@@ -126,10 +130,12 @@ describe('CDNLoader', () => {
         });
 
         it('should gracefully handle errors', () => {
+            const error = new Error('createElement error');
             mockDocument.createElement.mockImplementation(() => {
-                throw new Error('createElement error');
+                throw error;
             });
             expect(() => loader.preconnect(['https://example.com'])).not.toThrow();
+            expect(context.console.error).toHaveBeenCalledWith('Preconnect failed:', error);
         });
     });
 


### PR DESCRIPTION
The preconnect function in `js/loader/cdnFallback.js` had an empty catch block, which made it difficult to diagnose issues when the origin preconnect logic failed. This change replaces the empty catch block with a `console.error` call that logs the failure message and the error object. Corresponding unit tests have been updated to mock the `console` object and assert that the error is correctly logged.

---
*PR created automatically by Jules for task [3483644528698337740](https://jules.google.com/task/3483644528698337740) started by @ryusoh*