### PR TITLE
test: identify and write robust unit tests for missing coverage areas

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -5,3 +5,11 @@
 ## 2025-03-01 - Testing window fallback structures
 
 **Learning:** When testing scripts that attach themselves globally like `window.AMBIENT_CONFIG = Object.assign({...}, window.AMBIENT_CONFIG)`, one must ensure the context provides a valid `Object` constructor and an empty initial `window` object to prevent `ReferenceError`s and allow successful assignment in the Node `vm` context.
+
+## 2025-03-16 - Standard Jest Coverage Reporting Limitations for VM Scripts
+
+**Learning:** Standard Jest coverage reporting (`--coverage`) natively reports 0% for browser scripts read via `fs.readFileSync` and evaluated in Node's `vm` context. Test coverage gaps for these files must be identified through manual codebase inspection alongside evaluating test suites.
+
+## 2025-03-16 - Service Worker Lifecycle and Strategy Mocking
+
+**Learning:** When unit testing the Service Worker (`sw.js`) in Node's `vm` context, provide robust manual mocks for `self` (including `addEventListener`, `skipWaiting`, `clients.claim`), `caches` (`open`, `match`, `keys`, `delete`), and global `fetch` to adequately simulate and test caching strategies and lifecycle events.

--- a/tests/js/ambient/ambient.test.js
+++ b/tests/js/ambient/ambient.test.js
@@ -1,0 +1,159 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('js/ambient/ambient.js', () => {
+    let context;
+    let code;
+    let mockSketch;
+
+    beforeEach(() => {
+        const sourcePath = path.resolve(__dirname, '../../../js/ambient/ambient.js');
+        code = fs.readFileSync(sourcePath, 'utf8');
+
+        mockSketch = {
+            create: jest.fn().mockReturnValue({
+                canvas: {
+                    className: '',
+                    style: {},
+                    clientWidth: 800,
+                    clientHeight: 600,
+                },
+                width: 800,
+                height: 600,
+            }),
+        };
+
+        context = {
+            window: {
+                matchMedia: jest.fn().mockReturnValue({ matches: false }),
+                innerWidth: 1200,
+                innerHeight: 800,
+                location: { search: '' },
+                URLSearchParams: require('url').URLSearchParams,
+                devicePixelRatio: 1,
+                performance: { now: () => 1000 },
+                Sketch: mockSketch,
+                sessionStorage: {
+                    getItem: jest.fn(),
+                    removeItem: jest.fn(),
+                },
+                console: console, // explicitly use console here for `trace && window.console` check
+            },
+            document: {
+                body: {
+                    getAttribute: jest.fn().mockReturnValue('home'),
+                },
+            },
+            Math: Math,
+            Date: Date,
+            console: console,
+            Object: Object,
+            String: String,
+        };
+
+        // Setup circular references
+        context.window.document = context.document;
+    });
+
+    test('initializes Sketch if conditions are met', () => {
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockSketch.create).toHaveBeenCalledWith({
+            container: context.document.body,
+            retina: true,
+            interval: 2,
+            globals: false,
+            autopause: true,
+        });
+
+        // Test if the controller is attached
+        expect(context.window.AmbientTransitionController).toBeDefined();
+        expect(typeof context.window.AmbientTransitionController.playIntro).toBe('function');
+        expect(typeof context.window.AmbientTransitionController.playExit).toBe('function');
+    });
+
+    test('does not initialize if window.Sketch is missing', () => {
+        delete context.window.Sketch;
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(context.window.AmbientTransitionController).toBeUndefined();
+    });
+
+    test('does not initialize if prefers-reduced-motion is true', () => {
+        context.window.matchMedia.mockReturnValue({ matches: true });
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockSketch.create).not.toHaveBeenCalled();
+    });
+
+    test('does not initialize if innerWidth is below minWidth (1024 by default)', () => {
+        context.window.innerWidth = 800;
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockSketch.create).not.toHaveBeenCalled();
+    });
+
+    test('initializes despite small width if ?ambient=on is forced', () => {
+        context.window.innerWidth = 800;
+        context.window.location.search = '?ambient=on';
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockSketch.create).toHaveBeenCalled();
+    });
+
+    test('handles ?ambient=debug correctly', () => {
+        context.window.location.search = '?ambient=debug';
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockSketch.create).toHaveBeenCalled();
+    });
+
+    test('handles ?ambient=trace correctly', () => {
+        context.window.location.search = '?ambient=trace';
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockSketch.create).toHaveBeenCalled();
+        expect(context.window.__ambient).toBeDefined();
+        expect(context.window.__ambient.config.zIndex).toBe(999);
+    });
+
+    test('AmbientTransitionController.playIntro changes transition state', () => {
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        const sketchInstance = mockSketch.create.mock.results[0].value;
+        sketchInstance.setup = jest.fn();
+
+        context.window.AmbientTransitionController.playIntro();
+
+        expect(sketchInstance.canvas.style.transition).toBe('opacity 0.4s ease');
+        expect(sketchInstance.canvas.style.opacity).toBe('1');
+    });
+
+    test('AmbientTransitionController.playExit changes transition state', () => {
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        const sketchInstance = mockSketch.create.mock.results[0].value;
+        sketchInstance.setup = jest.fn();
+
+        context.window.AmbientTransitionController.playExit();
+
+        expect(sketchInstance.canvas.style.transition).toBe('opacity 0.4s ease');
+        expect(sketchInstance.canvas.style.opacity).toBe('1');
+    });
+});

--- a/tests/js/cursor-init.test.js
+++ b/tests/js/cursor-init.test.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('js/cursor-init.js', () => {
+    let context;
+    let code;
+    let mockInitCursor;
+
+    beforeEach(() => {
+        // We replace the import statement to make it executable in the VM context
+        const sourcePath = path.resolve(__dirname, '../../js/cursor-init.js');
+        const originalCode = fs.readFileSync(sourcePath, 'utf8');
+        code = originalCode.replace("import { initCursor } from './vendor/cursor.js';", '');
+
+        mockInitCursor = jest.fn().mockReturnValue({ cursor: { id: 'mocked-cursor' } });
+
+        context = {
+            window: {},
+            document: {
+                addEventListener: jest.fn((event, cb) => {
+                    if (event === 'DOMContentLoaded') {
+                        // We store the callback to call it manually
+                        context.__domContentLoadedCb = cb;
+                    }
+                }),
+            },
+            initCursor: mockInitCursor,
+            console: console,
+        };
+    });
+
+    test('adds a DOMContentLoaded event listener', () => {
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(context.document.addEventListener).toHaveBeenCalledWith(
+            'DOMContentLoaded',
+            expect.any(Function)
+        );
+    });
+
+    test('exits early if window.gsap is not defined', () => {
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        // Trigger DOMContentLoaded
+        context.__domContentLoadedCb();
+
+        expect(mockInitCursor).not.toHaveBeenCalled();
+        expect(context.window.cursorInstances).toBeUndefined();
+    });
+
+    test('initializes cursor if window.gsap is available', () => {
+        context.window.gsap = {}; // Mock GSAP
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        // Trigger DOMContentLoaded
+        context.__domContentLoadedCb();
+
+        expect(mockInitCursor).toHaveBeenCalledWith({
+            cursor: {
+                hoverTargets: 'a, button, .container li',
+                followEase: 0.4,
+                fadeEase: 0.1,
+                hoverScale: 3,
+            },
+        });
+
+        expect(context.window.cursorInstances).toBeDefined();
+        expect(context.window.cursorInstances.cursor).toEqual({ id: 'mocked-cursor' });
+    });
+});

--- a/tests/js/sw.test.js
+++ b/tests/js/sw.test.js
@@ -188,6 +188,71 @@ describe('Service Worker', () => {
             await new Promise(process.nextTick);
             expect(mockCache.put).toHaveBeenCalledWith(mockRequest, mockResponseClone);
         });
+
+        test('should skip caching if response is invalid (e.g. status 500) during Cache First fallback', async () => {
+            const fetchHandler = getEventHandler('fetch');
+            const mockRequest = {
+                url: 'https://example.com/images/fail.png',
+                destination: 'image',
+                headers: { has: jest.fn().mockReturnValue(false) },
+            };
+            const mockEvent = {
+                request: mockRequest,
+                respondWith: jest.fn(),
+            };
+
+            mockCaches.match.mockResolvedValue(undefined); // Cache miss
+
+            const mockResponse = {
+                ok: false,
+                status: 500,
+                type: 'basic',
+                headers: { get: jest.fn().mockReturnValue(null) },
+            };
+            mockFetch.mockResolvedValue(mockResponse);
+
+            fetchHandler(mockEvent);
+
+            const respondWithPromise = mockEvent.respondWith.mock.calls[0][0];
+            const result = await respondWithPromise;
+
+            expect(mockFetch).toHaveBeenCalledWith(mockRequest);
+            expect(result).toBe(mockResponse);
+            // Cache should not be put
+            expect(mockCache.put).not.toHaveBeenCalled();
+        });
+
+        test('should skip caching if request has range headers during Cache First fallback', async () => {
+            const fetchHandler = getEventHandler('fetch');
+            const mockRequest = {
+                url: 'https://example.com/images/large.jpg',
+                destination: 'image',
+                headers: { has: jest.fn().mockReturnValue(true) }, // simulate range header
+            };
+            const mockEvent = {
+                request: mockRequest,
+                respondWith: jest.fn(),
+            };
+
+            mockCaches.match.mockResolvedValue(undefined);
+
+            const mockResponse = {
+                ok: true,
+                status: 200,
+                type: 'basic',
+                headers: { get: jest.fn().mockReturnValue(null) },
+            };
+            mockFetch.mockResolvedValue(mockResponse);
+
+            fetchHandler(mockEvent);
+
+            const respondWithPromise = mockEvent.respondWith.mock.calls[0][0];
+            const result = await respondWithPromise;
+
+            expect(mockFetch).toHaveBeenCalledWith(mockRequest);
+            expect(result).toBe(mockResponse);
+            expect(mockCache.put).not.toHaveBeenCalled();
+        });
     });
 
     describe('Network Fallback (Mutable assets)', () => {
@@ -257,6 +322,36 @@ describe('Service Worker', () => {
 
             await new Promise(process.nextTick);
             expect(mockCache.put).toHaveBeenCalledWith(mockRequest, mockResponseClone);
+        });
+
+        test('should skip caching if response is invalid during Network First', async () => {
+            const fetchHandler = getEventHandler('fetch');
+            const mockRequest = {
+                url: 'https://example.com/api/data.json',
+                destination: '',
+                headers: { has: jest.fn().mockReturnValue(false) },
+            };
+            const mockEvent = {
+                request: mockRequest,
+                respondWith: jest.fn(),
+            };
+
+            const mockResponse = {
+                ok: false,
+                status: 404, // Invalid status
+                type: 'basic',
+                headers: { get: jest.fn().mockReturnValue(null) },
+            };
+            mockFetch.mockResolvedValue(mockResponse);
+
+            fetchHandler(mockEvent);
+
+            const respondWithPromise = mockEvent.respondWith.mock.calls[0][0];
+            const result = await respondWithPromise;
+
+            expect(mockFetch).toHaveBeenCalledWith(mockRequest);
+            expect(result).toBe(mockResponse);
+            expect(mockCache.put).not.toHaveBeenCalled();
         });
 
         test('should return undefined when both network and cache fail', async () => {


### PR DESCRIPTION
This PR introduces comprehensive tests for three critical application areas previously lacking measurable test coverage due to Node VM execution context mapping constraints. The tests enforce behaviors for early exits based on environments (GSAP/`prefers-reduced-motion`) and cache intercept logic when handling range requests.

### Changes:
1. **`tests/js/cursor-init.test.js`:** Added DOMContentLoaded event listener attachments and parameter verification for `initCursor`.
2. **`tests/js/ambient/ambient.test.js`:** Added coverage for sketching dependencies, query params (`?ambient=trace`), and transition controls.
3. **`tests/js/sw.test.js`:** Augmented the Service Worker suite to address branch inadequacies for `isValidResponse` edge cases handling invalid statuses (e.g., 500) and explicit `Range` headers triggering mutable fallbacks.
4. **`.jules/testpilot.md`:** Documented critical learnings relating to Jest's coverage mapping gaps and Service Worker mocking structures.

---
*PR created automatically by Jules for task [15588080612877891253](https://jules.google.com/task/15588080612877891253) started by @ryusoh*