### PR TITLE
🎨 Palette: Add Escape key shortcut to return home

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,8 @@
 
 **Learning:** Using an HTML `<table>` element purely for layout purposes (such as aligning navigation links alongside a category label) will cause screen readers to announce it as a data table with rows and columns, creating a confusing and verbose experience for non-visual users.
 **Action:** Always add `role="presentation"` (or `role="none"`) to layout tables. This strips away the table semantics so that assistive technologies treat the contents as normal layout elements, significantly improving the non-visual user experience without altering the visual structure or relying on new CSS layouts.
+
+## 2026-03-16 - Escape Route
+
+**Learning:** Users often expect standard "Escape" keys to exit immersive, gallery-style views, similar to closing a modal or lightbox. Providing explicit keyboard navigation out of these isolated views reduces friction significantly for keyboard users.
+**Action:** When creating standalone visual projects or deeply nested immersive layouts, ensure `Escape` is bound to navigating "Back" to the main context and exposed via `aria-keyshortcuts`.

--- a/js/block-navigation.js
+++ b/js/block-navigation.js
@@ -358,6 +358,15 @@
             return;
         }
 
+        if (event.key === 'Escape') {
+            const backButton = document.querySelector('.nav-back');
+            if (backButton) {
+                event.preventDefault();
+                backButton.click();
+            }
+            return;
+        }
+
         if (!KEY_FORWARD.has(event.key) && !KEY_BACKWARD.has(event.key)) {
             return;
         }

--- a/p1/index.html
+++ b/p1/index.html
@@ -123,7 +123,7 @@
             <!-- Back Home -->
 
             <!-- prettier-ignore -->
-            <a class="nav-back" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+            <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
                 <i class="fa fa-chevron-left" aria-hidden="true"></i>
             </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -123,7 +123,7 @@
             <!-- Back Home -->
 
             <!-- prettier-ignore -->
-            <a class="nav-back" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+            <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
                 <i class="fa fa-chevron-left" aria-hidden="true"></i>
             </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -117,7 +117,7 @@
             <!-- Back Home -->
 
             <!-- prettier-ignore -->
-            <a class="nav-back" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+            <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
                 <i class="fa fa-chevron-left" aria-hidden="true"></i>
             </a>
 


### PR DESCRIPTION
💡 What: Added an `Escape` key shortcut to navigate back to the home view from image galleries.
🎯 Why: Improves keyboard accessibility and provides a common, intuitive way for users to exit a gallery view.
♿ Accessibility: Added `aria-keyshortcuts="Escape"` to the `.nav-back` anchor tags to expose the shortcut to screen readers. Added a journal entry about keyboard navigation shortcuts in gallery views.

---
*PR created automatically by Jules for task [6349063032859337323](https://jules.google.com/task/6349063032859337323) started by @ryusoh*