### PR TITLE
🎨 Palette: Enhance contrast and focus states on portfolio links

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -401,23 +401,27 @@ footer {
     text-align: left; /* Align link text to the left, especially if it wraps */
     font-size: 1.2em; /* Base font size for this cell, links can override */
     letter-spacing: 1px;
-    opacity: 0.8; /* Makes the text slightly transparent */
 }
 
 #nav .portfolio-link a {
     text-decoration: none; /* Removes underline from links by default */
     display: block; /* Allows padding/margin if needed, and better click area */
     color: white;
+    opacity: 0.8; /* Makes the text slightly transparent initially */
     /* font-family: 'Lobster', cursive; */ /* Removed to inherit font from parent */
     font-weight: bold; /* Match the "Portfolio" text weight */
     padding: 0.2em 0.4em 0.6em 0.4em; /* top, right&left, bottom - adjusted for box effect */
-    transition: background-color 0.3s ease; /* Smooth transition for the background */
+    transition:
+        background-color 0.3s ease,
+        opacity 0.3s ease; /* Smooth transition for the background and opacity */
 }
 
-#nav .portfolio-link a:hover {
+#nav .portfolio-link a:hover,
+#nav .portfolio-link a:focus {
     background-color: rgba(255, 255, 255, 0.1); /* Light semi-transparent box */
     /* Or for a darker box: background-color: rgba(0, 0, 0, 0.2); */
     border-radius: 3px; /* Optional: rounded corners for the box */
+    opacity: 1; /* Restore full contrast on hover/focus */
 }
 
 #headline {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,4748 @@
+lockfileVersion: '9.0'
+
+settings:
+    autoInstallPeers: true
+    excludeLinksFromLockfile: false
+
+importers:
+    .:
+        devDependencies:
+            '@stylistic/stylelint-plugin':
+                specifier: ^4.0.0
+                version: 4.0.1(stylelint@16.26.1)
+            eslint:
+                specifier: ^9.17.0
+                version: 9.39.4
+            jest:
+                specifier: ^29.7.0
+                version: 29.7.0(@types/node@25.5.0)
+            prettier:
+                specifier: ^3.5.2
+                version: 3.8.1
+            stylelint:
+                specifier: ^16.22.0
+                version: 16.26.1
+
+packages:
+    '@babel/code-frame@7.29.0':
+        resolution:
+            {
+                integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/compat-data@7.29.0':
+        resolution:
+            {
+                integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/core@7.29.0':
+        resolution:
+            {
+                integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/generator@7.29.1':
+        resolution:
+            {
+                integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/helper-compilation-targets@7.28.6':
+        resolution:
+            {
+                integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/helper-globals@7.28.0':
+        resolution:
+            {
+                integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/helper-module-imports@7.28.6':
+        resolution:
+            {
+                integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/helper-module-transforms@7.28.6':
+        resolution:
+            {
+                integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==,
+            }
+        engines: { node: '>=6.9.0' }
+        peerDependencies:
+            '@babel/core': ^7.0.0
+
+    '@babel/helper-plugin-utils@7.28.6':
+        resolution:
+            {
+                integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/helper-string-parser@7.27.1':
+        resolution:
+            {
+                integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/helper-validator-identifier@7.28.5':
+        resolution:
+            {
+                integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/helper-validator-option@7.27.1':
+        resolution:
+            {
+                integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/helpers@7.29.2':
+        resolution:
+            {
+                integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/parser@7.29.2':
+        resolution:
+            {
+                integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==,
+            }
+        engines: { node: '>=6.0.0' }
+        hasBin: true
+
+    '@babel/plugin-syntax-async-generators@7.8.4':
+        resolution:
+            {
+                integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-bigint@7.8.3':
+        resolution:
+            {
+                integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-class-properties@7.12.13':
+        resolution:
+            {
+                integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-class-static-block@7.14.5':
+        resolution:
+            {
+                integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==,
+            }
+        engines: { node: '>=6.9.0' }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-import-attributes@7.28.6':
+        resolution:
+            {
+                integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==,
+            }
+        engines: { node: '>=6.9.0' }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-import-meta@7.10.4':
+        resolution:
+            {
+                integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-json-strings@7.8.3':
+        resolution:
+            {
+                integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-jsx@7.28.6':
+        resolution:
+            {
+                integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==,
+            }
+        engines: { node: '>=6.9.0' }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
+        resolution:
+            {
+                integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
+        resolution:
+            {
+                integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-numeric-separator@7.10.4':
+        resolution:
+            {
+                integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-object-rest-spread@7.8.3':
+        resolution:
+            {
+                integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-optional-catch-binding@7.8.3':
+        resolution:
+            {
+                integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-optional-chaining@7.8.3':
+        resolution:
+            {
+                integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-private-property-in-object@7.14.5':
+        resolution:
+            {
+                integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==,
+            }
+        engines: { node: '>=6.9.0' }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-top-level-await@7.14.5':
+        resolution:
+            {
+                integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==,
+            }
+        engines: { node: '>=6.9.0' }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/plugin-syntax-typescript@7.28.6':
+        resolution:
+            {
+                integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==,
+            }
+        engines: { node: '>=6.9.0' }
+        peerDependencies:
+            '@babel/core': ^7.0.0-0
+
+    '@babel/template@7.28.6':
+        resolution:
+            {
+                integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/traverse@7.29.0':
+        resolution:
+            {
+                integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@babel/types@7.29.0':
+        resolution:
+            {
+                integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    '@bcoe/v8-coverage@0.2.3':
+        resolution:
+            {
+                integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==,
+            }
+
+    '@cacheable/memory@2.0.8':
+        resolution:
+            {
+                integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==,
+            }
+
+    '@cacheable/utils@2.4.0':
+        resolution:
+            {
+                integrity: sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==,
+            }
+
+    '@csstools/css-parser-algorithms@3.0.5':
+        resolution:
+            {
+                integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==,
+            }
+        engines: { node: '>=18' }
+        peerDependencies:
+            '@csstools/css-tokenizer': ^3.0.4
+
+    '@csstools/css-syntax-patches-for-csstree@1.1.1':
+        resolution:
+            {
+                integrity: sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==,
+            }
+        peerDependencies:
+            css-tree: ^3.2.1
+        peerDependenciesMeta:
+            css-tree:
+                optional: true
+
+    '@csstools/css-tokenizer@3.0.4':
+        resolution:
+            {
+                integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==,
+            }
+        engines: { node: '>=18' }
+
+    '@csstools/media-query-list-parser@4.0.3':
+        resolution:
+            {
+                integrity: sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==,
+            }
+        engines: { node: '>=18' }
+        peerDependencies:
+            '@csstools/css-parser-algorithms': ^3.0.5
+            '@csstools/css-tokenizer': ^3.0.4
+
+    '@csstools/selector-specificity@5.0.0':
+        resolution:
+            {
+                integrity: sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==,
+            }
+        engines: { node: '>=18' }
+        peerDependencies:
+            postcss-selector-parser: ^7.0.0
+
+    '@dual-bundle/import-meta-resolve@4.2.1':
+        resolution:
+            {
+                integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==,
+            }
+
+    '@eslint-community/eslint-utils@4.9.1':
+        resolution:
+            {
+                integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==,
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+        peerDependencies:
+            eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+    '@eslint-community/regexpp@4.12.2':
+        resolution:
+            {
+                integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==,
+            }
+        engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
+
+    '@eslint/config-array@0.21.2':
+        resolution:
+            {
+                integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@eslint/config-helpers@0.4.2':
+        resolution:
+            {
+                integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@eslint/core@0.17.0':
+        resolution:
+            {
+                integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@eslint/eslintrc@3.3.5':
+        resolution:
+            {
+                integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@eslint/js@9.39.4':
+        resolution:
+            {
+                integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@eslint/object-schema@2.1.7':
+        resolution:
+            {
+                integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@eslint/plugin-kit@0.4.1':
+        resolution:
+            {
+                integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    '@humanfs/core@0.19.1':
+        resolution:
+            {
+                integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+            }
+        engines: { node: '>=18.18.0' }
+
+    '@humanfs/node@0.16.7':
+        resolution:
+            {
+                integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==,
+            }
+        engines: { node: '>=18.18.0' }
+
+    '@humanwhocodes/module-importer@1.0.1':
+        resolution:
+            {
+                integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
+            }
+        engines: { node: '>=12.22' }
+
+    '@humanwhocodes/retry@0.4.3':
+        resolution:
+            {
+                integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
+            }
+        engines: { node: '>=18.18' }
+
+    '@istanbuljs/load-nyc-config@1.1.0':
+        resolution:
+            {
+                integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==,
+            }
+        engines: { node: '>=8' }
+
+    '@istanbuljs/schema@0.1.3':
+        resolution:
+            {
+                integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==,
+            }
+        engines: { node: '>=8' }
+
+    '@jest/console@29.7.0':
+        resolution:
+            {
+                integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/core@29.7.0':
+        resolution:
+            {
+                integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+        peerDependencies:
+            node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+        peerDependenciesMeta:
+            node-notifier:
+                optional: true
+
+    '@jest/environment@29.7.0':
+        resolution:
+            {
+                integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/expect-utils@29.7.0':
+        resolution:
+            {
+                integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/expect@29.7.0':
+        resolution:
+            {
+                integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/fake-timers@29.7.0':
+        resolution:
+            {
+                integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/globals@29.7.0':
+        resolution:
+            {
+                integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/reporters@29.7.0':
+        resolution:
+            {
+                integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+        peerDependencies:
+            node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+        peerDependenciesMeta:
+            node-notifier:
+                optional: true
+
+    '@jest/schemas@29.6.3':
+        resolution:
+            {
+                integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/source-map@29.6.3':
+        resolution:
+            {
+                integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/test-result@29.7.0':
+        resolution:
+            {
+                integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/test-sequencer@29.7.0':
+        resolution:
+            {
+                integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/transform@29.7.0':
+        resolution:
+            {
+                integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/types@29.6.3':
+        resolution:
+            {
+                integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jridgewell/gen-mapping@0.3.13':
+        resolution:
+            {
+                integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
+            }
+
+    '@jridgewell/remapping@2.3.5':
+        resolution:
+            {
+                integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
+            }
+
+    '@jridgewell/resolve-uri@3.1.2':
+        resolution:
+            {
+                integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+            }
+        engines: { node: '>=6.0.0' }
+
+    '@jridgewell/sourcemap-codec@1.5.5':
+        resolution:
+            {
+                integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+            }
+
+    '@jridgewell/trace-mapping@0.3.31':
+        resolution:
+            {
+                integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
+            }
+
+    '@keyv/bigmap@1.3.1':
+        resolution:
+            {
+                integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==,
+            }
+        engines: { node: '>= 18' }
+        peerDependencies:
+            keyv: ^5.6.0
+
+    '@keyv/serialize@1.1.1':
+        resolution:
+            {
+                integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==,
+            }
+
+    '@nodelib/fs.scandir@2.1.5':
+        resolution:
+            {
+                integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
+            }
+        engines: { node: '>= 8' }
+
+    '@nodelib/fs.stat@2.0.5':
+        resolution:
+            {
+                integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
+            }
+        engines: { node: '>= 8' }
+
+    '@nodelib/fs.walk@1.2.8':
+        resolution:
+            {
+                integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
+            }
+        engines: { node: '>= 8' }
+
+    '@sinclair/typebox@0.27.10':
+        resolution:
+            {
+                integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==,
+            }
+
+    '@sinonjs/commons@3.0.1':
+        resolution:
+            {
+                integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==,
+            }
+
+    '@sinonjs/fake-timers@10.3.0':
+        resolution:
+            {
+                integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==,
+            }
+
+    '@stylistic/stylelint-plugin@4.0.1':
+        resolution:
+            {
+                integrity: sha512-jKZSZr/S/NehfgayNJI3O/JEq+W5lSeHUJNvdOebRPNFP2ZylTbAx/p5qR8scQFpiVzy1VQM9R+G0kIB62r1Pw==,
+            }
+        engines: { node: ^18.12 || >=20.9 }
+        peerDependencies:
+            stylelint: ^16.22.0
+
+    '@types/babel__core@7.20.5':
+        resolution:
+            {
+                integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==,
+            }
+
+    '@types/babel__generator@7.27.0':
+        resolution:
+            {
+                integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==,
+            }
+
+    '@types/babel__template@7.4.4':
+        resolution:
+            {
+                integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==,
+            }
+
+    '@types/babel__traverse@7.28.0':
+        resolution:
+            {
+                integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
+            }
+
+    '@types/estree@1.0.8':
+        resolution:
+            {
+                integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+            }
+
+    '@types/graceful-fs@4.1.9':
+        resolution:
+            {
+                integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==,
+            }
+
+    '@types/istanbul-lib-coverage@2.0.6':
+        resolution:
+            {
+                integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==,
+            }
+
+    '@types/istanbul-lib-report@3.0.3':
+        resolution:
+            {
+                integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==,
+            }
+
+    '@types/istanbul-reports@3.0.4':
+        resolution:
+            {
+                integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==,
+            }
+
+    '@types/json-schema@7.0.15':
+        resolution:
+            {
+                integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+            }
+
+    '@types/node@25.5.0':
+        resolution:
+            {
+                integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==,
+            }
+
+    '@types/stack-utils@2.0.3':
+        resolution:
+            {
+                integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==,
+            }
+
+    '@types/yargs-parser@21.0.3':
+        resolution:
+            {
+                integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==,
+            }
+
+    '@types/yargs@17.0.35':
+        resolution:
+            {
+                integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==,
+            }
+
+    acorn-jsx@5.3.2:
+        resolution:
+            {
+                integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
+            }
+        peerDependencies:
+            acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+    acorn@8.16.0:
+        resolution:
+            {
+                integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
+            }
+        engines: { node: '>=0.4.0' }
+        hasBin: true
+
+    ajv@6.14.0:
+        resolution:
+            {
+                integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==,
+            }
+
+    ajv@8.18.0:
+        resolution:
+            {
+                integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==,
+            }
+
+    ansi-escapes@4.3.2:
+        resolution:
+            {
+                integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==,
+            }
+        engines: { node: '>=8' }
+
+    ansi-regex@5.0.1:
+        resolution:
+            {
+                integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+            }
+        engines: { node: '>=8' }
+
+    ansi-styles@4.3.0:
+        resolution:
+            {
+                integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+            }
+        engines: { node: '>=8' }
+
+    ansi-styles@5.2.0:
+        resolution:
+            {
+                integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==,
+            }
+        engines: { node: '>=10' }
+
+    anymatch@3.1.3:
+        resolution:
+            {
+                integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
+            }
+        engines: { node: '>= 8' }
+
+    argparse@1.0.10:
+        resolution:
+            {
+                integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==,
+            }
+
+    argparse@2.0.1:
+        resolution:
+            {
+                integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+            }
+
+    array-union@2.1.0:
+        resolution:
+            {
+                integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
+            }
+        engines: { node: '>=8' }
+
+    astral-regex@2.0.0:
+        resolution:
+            {
+                integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==,
+            }
+        engines: { node: '>=8' }
+
+    babel-jest@29.7.0:
+        resolution:
+            {
+                integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+        peerDependencies:
+            '@babel/core': ^7.8.0
+
+    babel-plugin-istanbul@6.1.1:
+        resolution:
+            {
+                integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==,
+            }
+        engines: { node: '>=8' }
+
+    babel-plugin-jest-hoist@29.6.3:
+        resolution:
+            {
+                integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    babel-preset-current-node-syntax@1.2.0:
+        resolution:
+            {
+                integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==,
+            }
+        peerDependencies:
+            '@babel/core': ^7.0.0 || ^8.0.0-0
+
+    babel-preset-jest@29.6.3:
+        resolution:
+            {
+                integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+        peerDependencies:
+            '@babel/core': ^7.0.0
+
+    balanced-match@1.0.2:
+        resolution:
+            {
+                integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+            }
+
+    balanced-match@2.0.0:
+        resolution:
+            {
+                integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==,
+            }
+
+    baseline-browser-mapping@2.10.8:
+        resolution:
+            {
+                integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==,
+            }
+        engines: { node: '>=6.0.0' }
+        hasBin: true
+
+    brace-expansion@1.1.12:
+        resolution:
+            {
+                integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
+            }
+
+    braces@3.0.3:
+        resolution:
+            {
+                integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
+            }
+        engines: { node: '>=8' }
+
+    browserslist@4.28.1:
+        resolution:
+            {
+                integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==,
+            }
+        engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+        hasBin: true
+
+    bser@2.1.1:
+        resolution:
+            {
+                integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==,
+            }
+
+    buffer-from@1.1.2:
+        resolution:
+            {
+                integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
+            }
+
+    cacheable@2.3.3:
+        resolution:
+            {
+                integrity: sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==,
+            }
+
+    callsites@3.1.0:
+        resolution:
+            {
+                integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
+            }
+        engines: { node: '>=6' }
+
+    camelcase@5.3.1:
+        resolution:
+            {
+                integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==,
+            }
+        engines: { node: '>=6' }
+
+    camelcase@6.3.0:
+        resolution:
+            {
+                integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==,
+            }
+        engines: { node: '>=10' }
+
+    caniuse-lite@1.0.30001780:
+        resolution:
+            {
+                integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==,
+            }
+
+    chalk@4.1.2:
+        resolution:
+            {
+                integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
+            }
+        engines: { node: '>=10' }
+
+    char-regex@1.0.2:
+        resolution:
+            {
+                integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==,
+            }
+        engines: { node: '>=10' }
+
+    ci-info@3.9.0:
+        resolution:
+            {
+                integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==,
+            }
+        engines: { node: '>=8' }
+
+    cjs-module-lexer@1.4.3:
+        resolution:
+            {
+                integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==,
+            }
+
+    cliui@8.0.1:
+        resolution:
+            {
+                integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
+            }
+        engines: { node: '>=12' }
+
+    co@4.6.0:
+        resolution:
+            {
+                integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==,
+            }
+        engines: { iojs: '>= 1.0.0', node: '>= 0.12.0' }
+
+    collect-v8-coverage@1.0.3:
+        resolution:
+            {
+                integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==,
+            }
+
+    color-convert@2.0.1:
+        resolution:
+            {
+                integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+            }
+        engines: { node: '>=7.0.0' }
+
+    color-name@1.1.4:
+        resolution:
+            {
+                integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+            }
+
+    colord@2.9.3:
+        resolution:
+            {
+                integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==,
+            }
+
+    concat-map@0.0.1:
+        resolution:
+            {
+                integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+            }
+
+    convert-source-map@2.0.0:
+        resolution:
+            {
+                integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+            }
+
+    cosmiconfig@9.0.1:
+        resolution:
+            {
+                integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==,
+            }
+        engines: { node: '>=14' }
+        peerDependencies:
+            typescript: '>=4.9.5'
+        peerDependenciesMeta:
+            typescript:
+                optional: true
+
+    create-jest@29.7.0:
+        resolution:
+            {
+                integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+        hasBin: true
+
+    cross-spawn@7.0.6:
+        resolution:
+            {
+                integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+            }
+        engines: { node: '>= 8' }
+
+    css-functions-list@3.3.3:
+        resolution:
+            {
+                integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==,
+            }
+        engines: { node: '>=12' }
+
+    css-tree@3.2.1:
+        resolution:
+            {
+                integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==,
+            }
+        engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
+
+    cssesc@3.0.0:
+        resolution:
+            {
+                integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
+            }
+        engines: { node: '>=4' }
+        hasBin: true
+
+    debug@4.4.3:
+        resolution:
+            {
+                integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+            }
+        engines: { node: '>=6.0' }
+        peerDependencies:
+            supports-color: '*'
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
+
+    dedent@1.7.2:
+        resolution:
+            {
+                integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==,
+            }
+        peerDependencies:
+            babel-plugin-macros: ^3.1.0
+        peerDependenciesMeta:
+            babel-plugin-macros:
+                optional: true
+
+    deep-is@0.1.4:
+        resolution:
+            {
+                integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
+            }
+
+    deepmerge@4.3.1:
+        resolution:
+            {
+                integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    detect-newline@3.1.0:
+        resolution:
+            {
+                integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==,
+            }
+        engines: { node: '>=8' }
+
+    diff-sequences@29.6.3:
+        resolution:
+            {
+                integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    dir-glob@3.0.1:
+        resolution:
+            {
+                integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==,
+            }
+        engines: { node: '>=8' }
+
+    electron-to-chromium@1.5.313:
+        resolution:
+            {
+                integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==,
+            }
+
+    emittery@0.13.1:
+        resolution:
+            {
+                integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==,
+            }
+        engines: { node: '>=12' }
+
+    emoji-regex@8.0.0:
+        resolution:
+            {
+                integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+            }
+
+    env-paths@2.2.1:
+        resolution:
+            {
+                integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==,
+            }
+        engines: { node: '>=6' }
+
+    error-ex@1.3.4:
+        resolution:
+            {
+                integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==,
+            }
+
+    escalade@3.2.0:
+        resolution:
+            {
+                integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
+            }
+        engines: { node: '>=6' }
+
+    escape-string-regexp@2.0.0:
+        resolution:
+            {
+                integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==,
+            }
+        engines: { node: '>=8' }
+
+    escape-string-regexp@4.0.0:
+        resolution:
+            {
+                integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
+            }
+        engines: { node: '>=10' }
+
+    eslint-scope@8.4.0:
+        resolution:
+            {
+                integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    eslint-visitor-keys@3.4.3:
+        resolution:
+            {
+                integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==,
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+
+    eslint-visitor-keys@4.2.1:
+        resolution:
+            {
+                integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    eslint@9.39.4:
+        resolution:
+            {
+                integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        hasBin: true
+        peerDependencies:
+            jiti: '*'
+        peerDependenciesMeta:
+            jiti:
+                optional: true
+
+    espree@10.4.0:
+        resolution:
+            {
+                integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    esprima@4.0.1:
+        resolution:
+            {
+                integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
+            }
+        engines: { node: '>=4' }
+        hasBin: true
+
+    esquery@1.7.0:
+        resolution:
+            {
+                integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==,
+            }
+        engines: { node: '>=0.10' }
+
+    esrecurse@4.3.0:
+        resolution:
+            {
+                integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+            }
+        engines: { node: '>=4.0' }
+
+    estraverse@5.3.0:
+        resolution:
+            {
+                integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
+            }
+        engines: { node: '>=4.0' }
+
+    esutils@2.0.3:
+        resolution:
+            {
+                integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    execa@5.1.1:
+        resolution:
+            {
+                integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==,
+            }
+        engines: { node: '>=10' }
+
+    exit@0.1.2:
+        resolution:
+            {
+                integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==,
+            }
+        engines: { node: '>= 0.8.0' }
+
+    expect@29.7.0:
+        resolution:
+            {
+                integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    fast-deep-equal@3.1.3:
+        resolution:
+            {
+                integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+            }
+
+    fast-glob@3.3.3:
+        resolution:
+            {
+                integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
+            }
+        engines: { node: '>=8.6.0' }
+
+    fast-json-stable-stringify@2.1.0:
+        resolution:
+            {
+                integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+            }
+
+    fast-levenshtein@2.0.6:
+        resolution:
+            {
+                integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+            }
+
+    fast-uri@3.1.0:
+        resolution:
+            {
+                integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
+            }
+
+    fastest-levenshtein@1.0.16:
+        resolution:
+            {
+                integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==,
+            }
+        engines: { node: '>= 4.9.1' }
+
+    fastq@1.20.1:
+        resolution:
+            {
+                integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==,
+            }
+
+    fb-watchman@2.0.2:
+        resolution:
+            {
+                integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==,
+            }
+
+    file-entry-cache@11.1.2:
+        resolution:
+            {
+                integrity: sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==,
+            }
+
+    file-entry-cache@8.0.0:
+        resolution:
+            {
+                integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
+            }
+        engines: { node: '>=16.0.0' }
+
+    fill-range@7.1.1:
+        resolution:
+            {
+                integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
+            }
+        engines: { node: '>=8' }
+
+    find-up@4.1.0:
+        resolution:
+            {
+                integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==,
+            }
+        engines: { node: '>=8' }
+
+    find-up@5.0.0:
+        resolution:
+            {
+                integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
+            }
+        engines: { node: '>=10' }
+
+    flat-cache@4.0.1:
+        resolution:
+            {
+                integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
+            }
+        engines: { node: '>=16' }
+
+    flat-cache@6.1.20:
+        resolution:
+            {
+                integrity: sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==,
+            }
+
+    flatted@3.4.2:
+        resolution:
+            {
+                integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
+            }
+
+    fs.realpath@1.0.0:
+        resolution:
+            {
+                integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==,
+            }
+
+    fsevents@2.3.3:
+        resolution:
+            {
+                integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+            }
+        engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+        os: [darwin]
+
+    function-bind@1.1.2:
+        resolution:
+            {
+                integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
+            }
+
+    gensync@1.0.0-beta.2:
+        resolution:
+            {
+                integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
+            }
+        engines: { node: '>=6.9.0' }
+
+    get-caller-file@2.0.5:
+        resolution:
+            {
+                integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
+            }
+        engines: { node: 6.* || 8.* || >= 10.* }
+
+    get-package-type@0.1.0:
+        resolution:
+            {
+                integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==,
+            }
+        engines: { node: '>=8.0.0' }
+
+    get-stream@6.0.1:
+        resolution:
+            {
+                integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==,
+            }
+        engines: { node: '>=10' }
+
+    glob-parent@5.1.2:
+        resolution:
+            {
+                integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
+            }
+        engines: { node: '>= 6' }
+
+    glob-parent@6.0.2:
+        resolution:
+            {
+                integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
+            }
+        engines: { node: '>=10.13.0' }
+
+    glob@7.2.3:
+        resolution:
+            {
+                integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==,
+            }
+        deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+    global-modules@2.0.0:
+        resolution:
+            {
+                integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==,
+            }
+        engines: { node: '>=6' }
+
+    global-prefix@3.0.0:
+        resolution:
+            {
+                integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==,
+            }
+        engines: { node: '>=6' }
+
+    globals@14.0.0:
+        resolution:
+            {
+                integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
+            }
+        engines: { node: '>=18' }
+
+    globby@11.1.0:
+        resolution:
+            {
+                integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==,
+            }
+        engines: { node: '>=10' }
+
+    globjoin@0.1.4:
+        resolution:
+            {
+                integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==,
+            }
+
+    graceful-fs@4.2.11:
+        resolution:
+            {
+                integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+            }
+
+    has-flag@4.0.0:
+        resolution:
+            {
+                integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+            }
+        engines: { node: '>=8' }
+
+    hashery@1.5.0:
+        resolution:
+            {
+                integrity: sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==,
+            }
+        engines: { node: '>=20' }
+
+    hasown@2.0.2:
+        resolution:
+            {
+                integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
+            }
+        engines: { node: '>= 0.4' }
+
+    hookified@1.15.1:
+        resolution:
+            {
+                integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==,
+            }
+
+    html-escaper@2.0.2:
+        resolution:
+            {
+                integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
+            }
+
+    html-tags@3.3.1:
+        resolution:
+            {
+                integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==,
+            }
+        engines: { node: '>=8' }
+
+    human-signals@2.1.0:
+        resolution:
+            {
+                integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==,
+            }
+        engines: { node: '>=10.17.0' }
+
+    ignore@5.3.2:
+        resolution:
+            {
+                integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
+            }
+        engines: { node: '>= 4' }
+
+    ignore@7.0.5:
+        resolution:
+            {
+                integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
+            }
+        engines: { node: '>= 4' }
+
+    import-fresh@3.3.1:
+        resolution:
+            {
+                integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
+            }
+        engines: { node: '>=6' }
+
+    import-local@3.2.0:
+        resolution:
+            {
+                integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==,
+            }
+        engines: { node: '>=8' }
+        hasBin: true
+
+    imurmurhash@0.1.4:
+        resolution:
+            {
+                integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
+            }
+        engines: { node: '>=0.8.19' }
+
+    inflight@1.0.6:
+        resolution:
+            {
+                integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==,
+            }
+        deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+    inherits@2.0.4:
+        resolution:
+            {
+                integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+            }
+
+    ini@1.3.8:
+        resolution:
+            {
+                integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
+            }
+
+    is-arrayish@0.2.1:
+        resolution:
+            {
+                integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
+            }
+
+    is-core-module@2.16.1:
+        resolution:
+            {
+                integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==,
+            }
+        engines: { node: '>= 0.4' }
+
+    is-extglob@2.1.1:
+        resolution:
+            {
+                integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    is-fullwidth-code-point@3.0.0:
+        resolution:
+            {
+                integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+            }
+        engines: { node: '>=8' }
+
+    is-generator-fn@2.1.0:
+        resolution:
+            {
+                integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==,
+            }
+        engines: { node: '>=6' }
+
+    is-glob@4.0.3:
+        resolution:
+            {
+                integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    is-number@7.0.0:
+        resolution:
+            {
+                integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
+            }
+        engines: { node: '>=0.12.0' }
+
+    is-plain-object@5.0.0:
+        resolution:
+            {
+                integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    is-stream@2.0.1:
+        resolution:
+            {
+                integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
+            }
+        engines: { node: '>=8' }
+
+    isexe@2.0.0:
+        resolution:
+            {
+                integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+            }
+
+    istanbul-lib-coverage@3.2.2:
+        resolution:
+            {
+                integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==,
+            }
+        engines: { node: '>=8' }
+
+    istanbul-lib-instrument@5.2.1:
+        resolution:
+            {
+                integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==,
+            }
+        engines: { node: '>=8' }
+
+    istanbul-lib-instrument@6.0.3:
+        resolution:
+            {
+                integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==,
+            }
+        engines: { node: '>=10' }
+
+    istanbul-lib-report@3.0.1:
+        resolution:
+            {
+                integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==,
+            }
+        engines: { node: '>=10' }
+
+    istanbul-lib-source-maps@4.0.1:
+        resolution:
+            {
+                integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==,
+            }
+        engines: { node: '>=10' }
+
+    istanbul-reports@3.2.0:
+        resolution:
+            {
+                integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==,
+            }
+        engines: { node: '>=8' }
+
+    jest-changed-files@29.7.0:
+        resolution:
+            {
+                integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-circus@29.7.0:
+        resolution:
+            {
+                integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-cli@29.7.0:
+        resolution:
+            {
+                integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+        hasBin: true
+        peerDependencies:
+            node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+        peerDependenciesMeta:
+            node-notifier:
+                optional: true
+
+    jest-config@29.7.0:
+        resolution:
+            {
+                integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+        peerDependencies:
+            '@types/node': '*'
+            ts-node: '>=9.0.0'
+        peerDependenciesMeta:
+            '@types/node':
+                optional: true
+            ts-node:
+                optional: true
+
+    jest-diff@29.7.0:
+        resolution:
+            {
+                integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-docblock@29.7.0:
+        resolution:
+            {
+                integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-each@29.7.0:
+        resolution:
+            {
+                integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-environment-node@29.7.0:
+        resolution:
+            {
+                integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-get-type@29.6.3:
+        resolution:
+            {
+                integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-haste-map@29.7.0:
+        resolution:
+            {
+                integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-leak-detector@29.7.0:
+        resolution:
+            {
+                integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-matcher-utils@29.7.0:
+        resolution:
+            {
+                integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-message-util@29.7.0:
+        resolution:
+            {
+                integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-mock@29.7.0:
+        resolution:
+            {
+                integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-pnp-resolver@1.2.3:
+        resolution:
+            {
+                integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==,
+            }
+        engines: { node: '>=6' }
+        peerDependencies:
+            jest-resolve: '*'
+        peerDependenciesMeta:
+            jest-resolve:
+                optional: true
+
+    jest-regex-util@29.6.3:
+        resolution:
+            {
+                integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-resolve-dependencies@29.7.0:
+        resolution:
+            {
+                integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-resolve@29.7.0:
+        resolution:
+            {
+                integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-runner@29.7.0:
+        resolution:
+            {
+                integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-runtime@29.7.0:
+        resolution:
+            {
+                integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-snapshot@29.7.0:
+        resolution:
+            {
+                integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-util@29.7.0:
+        resolution:
+            {
+                integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-validate@29.7.0:
+        resolution:
+            {
+                integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-watcher@29.7.0:
+        resolution:
+            {
+                integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-worker@29.7.0:
+        resolution:
+            {
+                integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest@29.7.0:
+        resolution:
+            {
+                integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+        hasBin: true
+        peerDependencies:
+            node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+        peerDependenciesMeta:
+            node-notifier:
+                optional: true
+
+    js-tokens@4.0.0:
+        resolution:
+            {
+                integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+            }
+
+    js-yaml@3.14.2:
+        resolution:
+            {
+                integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==,
+            }
+        hasBin: true
+
+    js-yaml@4.1.1:
+        resolution:
+            {
+                integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+            }
+        hasBin: true
+
+    jsesc@3.1.0:
+        resolution:
+            {
+                integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
+            }
+        engines: { node: '>=6' }
+        hasBin: true
+
+    json-buffer@3.0.1:
+        resolution:
+            {
+                integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
+            }
+
+    json-parse-even-better-errors@2.3.1:
+        resolution:
+            {
+                integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
+            }
+
+    json-schema-traverse@0.4.1:
+        resolution:
+            {
+                integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+            }
+
+    json-schema-traverse@1.0.0:
+        resolution:
+            {
+                integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
+            }
+
+    json-stable-stringify-without-jsonify@1.0.1:
+        resolution:
+            {
+                integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
+            }
+
+    json5@2.2.3:
+        resolution:
+            {
+                integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
+            }
+        engines: { node: '>=6' }
+        hasBin: true
+
+    keyv@4.5.4:
+        resolution:
+            {
+                integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
+            }
+
+    keyv@5.6.0:
+        resolution:
+            {
+                integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==,
+            }
+
+    kind-of@6.0.3:
+        resolution:
+            {
+                integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    kleur@3.0.3:
+        resolution:
+            {
+                integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
+            }
+        engines: { node: '>=6' }
+
+    known-css-properties@0.37.0:
+        resolution:
+            {
+                integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==,
+            }
+
+    leven@3.1.0:
+        resolution:
+            {
+                integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==,
+            }
+        engines: { node: '>=6' }
+
+    levn@0.4.1:
+        resolution:
+            {
+                integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
+            }
+        engines: { node: '>= 0.8.0' }
+
+    lines-and-columns@1.2.4:
+        resolution:
+            {
+                integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
+            }
+
+    locate-path@5.0.0:
+        resolution:
+            {
+                integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==,
+            }
+        engines: { node: '>=8' }
+
+    locate-path@6.0.0:
+        resolution:
+            {
+                integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
+            }
+        engines: { node: '>=10' }
+
+    lodash.merge@4.6.2:
+        resolution:
+            {
+                integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+            }
+
+    lodash.truncate@4.4.2:
+        resolution:
+            {
+                integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==,
+            }
+
+    lru-cache@5.1.1:
+        resolution:
+            {
+                integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
+            }
+
+    make-dir@4.0.0:
+        resolution:
+            {
+                integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==,
+            }
+        engines: { node: '>=10' }
+
+    makeerror@1.0.12:
+        resolution:
+            {
+                integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==,
+            }
+
+    mathml-tag-names@2.1.3:
+        resolution:
+            {
+                integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==,
+            }
+
+    mdn-data@2.27.1:
+        resolution:
+            {
+                integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
+            }
+
+    meow@13.2.0:
+        resolution:
+            {
+                integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==,
+            }
+        engines: { node: '>=18' }
+
+    merge-stream@2.0.0:
+        resolution:
+            {
+                integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==,
+            }
+
+    merge2@1.4.1:
+        resolution:
+            {
+                integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
+            }
+        engines: { node: '>= 8' }
+
+    micromatch@4.0.8:
+        resolution:
+            {
+                integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
+            }
+        engines: { node: '>=8.6' }
+
+    mimic-fn@2.1.0:
+        resolution:
+            {
+                integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==,
+            }
+        engines: { node: '>=6' }
+
+    minimatch@3.1.5:
+        resolution:
+            {
+                integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==,
+            }
+
+    ms@2.1.3:
+        resolution:
+            {
+                integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+            }
+
+    nanoid@3.3.11:
+        resolution:
+            {
+                integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+            }
+        engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+        hasBin: true
+
+    natural-compare@1.4.0:
+        resolution:
+            {
+                integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
+            }
+
+    node-int64@0.4.0:
+        resolution:
+            {
+                integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==,
+            }
+
+    node-releases@2.0.36:
+        resolution:
+            {
+                integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==,
+            }
+
+    normalize-path@3.0.0:
+        resolution:
+            {
+                integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    npm-run-path@4.0.1:
+        resolution:
+            {
+                integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==,
+            }
+        engines: { node: '>=8' }
+
+    once@1.4.0:
+        resolution:
+            {
+                integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
+            }
+
+    onetime@5.1.2:
+        resolution:
+            {
+                integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
+            }
+        engines: { node: '>=6' }
+
+    optionator@0.9.4:
+        resolution:
+            {
+                integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
+            }
+        engines: { node: '>= 0.8.0' }
+
+    p-limit@2.3.0:
+        resolution:
+            {
+                integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==,
+            }
+        engines: { node: '>=6' }
+
+    p-limit@3.1.0:
+        resolution:
+            {
+                integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
+            }
+        engines: { node: '>=10' }
+
+    p-locate@4.1.0:
+        resolution:
+            {
+                integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==,
+            }
+        engines: { node: '>=8' }
+
+    p-locate@5.0.0:
+        resolution:
+            {
+                integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+            }
+        engines: { node: '>=10' }
+
+    p-try@2.2.0:
+        resolution:
+            {
+                integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==,
+            }
+        engines: { node: '>=6' }
+
+    parent-module@1.0.1:
+        resolution:
+            {
+                integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
+            }
+        engines: { node: '>=6' }
+
+    parse-json@5.2.0:
+        resolution:
+            {
+                integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==,
+            }
+        engines: { node: '>=8' }
+
+    path-exists@4.0.0:
+        resolution:
+            {
+                integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+            }
+        engines: { node: '>=8' }
+
+    path-is-absolute@1.0.1:
+        resolution:
+            {
+                integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    path-key@3.1.1:
+        resolution:
+            {
+                integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+            }
+        engines: { node: '>=8' }
+
+    path-parse@1.0.7:
+        resolution:
+            {
+                integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
+            }
+
+    path-type@4.0.0:
+        resolution:
+            {
+                integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
+            }
+        engines: { node: '>=8' }
+
+    picocolors@1.1.1:
+        resolution:
+            {
+                integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+            }
+
+    picomatch@2.3.1:
+        resolution:
+            {
+                integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
+            }
+        engines: { node: '>=8.6' }
+
+    pirates@4.0.7:
+        resolution:
+            {
+                integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
+            }
+        engines: { node: '>= 6' }
+
+    pkg-dir@4.2.0:
+        resolution:
+            {
+                integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==,
+            }
+        engines: { node: '>=8' }
+
+    postcss-resolve-nested-selector@0.1.6:
+        resolution:
+            {
+                integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==,
+            }
+
+    postcss-safe-parser@7.0.1:
+        resolution:
+            {
+                integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==,
+            }
+        engines: { node: '>=18.0' }
+        peerDependencies:
+            postcss: ^8.4.31
+
+    postcss-selector-parser@7.1.1:
+        resolution:
+            {
+                integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==,
+            }
+        engines: { node: '>=4' }
+
+    postcss-value-parser@4.2.0:
+        resolution:
+            {
+                integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
+            }
+
+    postcss@8.5.8:
+        resolution:
+            {
+                integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
+            }
+        engines: { node: ^10 || ^12 || >=14 }
+
+    prelude-ls@1.2.1:
+        resolution:
+            {
+                integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
+            }
+        engines: { node: '>= 0.8.0' }
+
+    prettier@3.8.1:
+        resolution:
+            {
+                integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
+            }
+        engines: { node: '>=14' }
+        hasBin: true
+
+    pretty-format@29.7.0:
+        resolution:
+            {
+                integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==,
+            }
+        engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    prompts@2.4.2:
+        resolution:
+            {
+                integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
+            }
+        engines: { node: '>= 6' }
+
+    punycode@2.3.1:
+        resolution:
+            {
+                integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+            }
+        engines: { node: '>=6' }
+
+    pure-rand@6.1.0:
+        resolution:
+            {
+                integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==,
+            }
+
+    qified@0.6.0:
+        resolution:
+            {
+                integrity: sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==,
+            }
+        engines: { node: '>=20' }
+
+    queue-microtask@1.2.3:
+        resolution:
+            {
+                integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
+            }
+
+    react-is@18.3.1:
+        resolution:
+            {
+                integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==,
+            }
+
+    require-directory@2.1.1:
+        resolution:
+            {
+                integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    require-from-string@2.0.2:
+        resolution:
+            {
+                integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    resolve-cwd@3.0.0:
+        resolution:
+            {
+                integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==,
+            }
+        engines: { node: '>=8' }
+
+    resolve-from@4.0.0:
+        resolution:
+            {
+                integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
+            }
+        engines: { node: '>=4' }
+
+    resolve-from@5.0.0:
+        resolution:
+            {
+                integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
+            }
+        engines: { node: '>=8' }
+
+    resolve.exports@2.0.3:
+        resolution:
+            {
+                integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==,
+            }
+        engines: { node: '>=10' }
+
+    resolve@1.22.11:
+        resolution:
+            {
+                integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==,
+            }
+        engines: { node: '>= 0.4' }
+        hasBin: true
+
+    reusify@1.1.0:
+        resolution:
+            {
+                integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
+            }
+        engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
+
+    run-parallel@1.2.0:
+        resolution:
+            {
+                integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
+            }
+
+    semver@6.3.1:
+        resolution:
+            {
+                integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
+            }
+        hasBin: true
+
+    semver@7.7.4:
+        resolution:
+            {
+                integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
+            }
+        engines: { node: '>=10' }
+        hasBin: true
+
+    shebang-command@2.0.0:
+        resolution:
+            {
+                integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+            }
+        engines: { node: '>=8' }
+
+    shebang-regex@3.0.0:
+        resolution:
+            {
+                integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+            }
+        engines: { node: '>=8' }
+
+    signal-exit@3.0.7:
+        resolution:
+            {
+                integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
+            }
+
+    signal-exit@4.1.0:
+        resolution:
+            {
+                integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
+            }
+        engines: { node: '>=14' }
+
+    sisteransi@1.0.5:
+        resolution:
+            {
+                integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
+            }
+
+    slash@3.0.0:
+        resolution:
+            {
+                integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
+            }
+        engines: { node: '>=8' }
+
+    slice-ansi@4.0.0:
+        resolution:
+            {
+                integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==,
+            }
+        engines: { node: '>=10' }
+
+    source-map-js@1.2.1:
+        resolution:
+            {
+                integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    source-map-support@0.5.13:
+        resolution:
+            {
+                integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==,
+            }
+
+    source-map@0.6.1:
+        resolution:
+            {
+                integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    sprintf-js@1.0.3:
+        resolution:
+            {
+                integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
+            }
+
+    stack-utils@2.0.6:
+        resolution:
+            {
+                integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==,
+            }
+        engines: { node: '>=10' }
+
+    string-length@4.0.2:
+        resolution:
+            {
+                integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==,
+            }
+        engines: { node: '>=10' }
+
+    string-width@4.2.3:
+        resolution:
+            {
+                integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+            }
+        engines: { node: '>=8' }
+
+    strip-ansi@6.0.1:
+        resolution:
+            {
+                integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+            }
+        engines: { node: '>=8' }
+
+    strip-bom@4.0.0:
+        resolution:
+            {
+                integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==,
+            }
+        engines: { node: '>=8' }
+
+    strip-final-newline@2.0.0:
+        resolution:
+            {
+                integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==,
+            }
+        engines: { node: '>=6' }
+
+    strip-json-comments@3.1.1:
+        resolution:
+            {
+                integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
+            }
+        engines: { node: '>=8' }
+
+    style-search@0.1.0:
+        resolution:
+            {
+                integrity: sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==,
+            }
+
+    stylelint@16.26.1:
+        resolution:
+            {
+                integrity: sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==,
+            }
+        engines: { node: '>=18.12.0' }
+        hasBin: true
+
+    supports-color@7.2.0:
+        resolution:
+            {
+                integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+            }
+        engines: { node: '>=8' }
+
+    supports-color@8.1.1:
+        resolution:
+            {
+                integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==,
+            }
+        engines: { node: '>=10' }
+
+    supports-hyperlinks@3.2.0:
+        resolution:
+            {
+                integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==,
+            }
+        engines: { node: '>=14.18' }
+
+    supports-preserve-symlinks-flag@1.0.0:
+        resolution:
+            {
+                integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
+            }
+        engines: { node: '>= 0.4' }
+
+    svg-tags@1.0.0:
+        resolution:
+            {
+                integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==,
+            }
+
+    table@6.9.0:
+        resolution:
+            {
+                integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==,
+            }
+        engines: { node: '>=10.0.0' }
+
+    test-exclude@6.0.0:
+        resolution:
+            {
+                integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==,
+            }
+        engines: { node: '>=8' }
+
+    tmpl@1.0.5:
+        resolution:
+            {
+                integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==,
+            }
+
+    to-regex-range@5.0.1:
+        resolution:
+            {
+                integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
+            }
+        engines: { node: '>=8.0' }
+
+    type-check@0.4.0:
+        resolution:
+            {
+                integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
+            }
+        engines: { node: '>= 0.8.0' }
+
+    type-detect@4.0.8:
+        resolution:
+            {
+                integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==,
+            }
+        engines: { node: '>=4' }
+
+    type-fest@0.21.3:
+        resolution:
+            {
+                integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==,
+            }
+        engines: { node: '>=10' }
+
+    undici-types@7.18.2:
+        resolution:
+            {
+                integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==,
+            }
+
+    update-browserslist-db@1.2.3:
+        resolution:
+            {
+                integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
+            }
+        hasBin: true
+        peerDependencies:
+            browserslist: '>= 4.21.0'
+
+    uri-js@4.4.1:
+        resolution:
+            {
+                integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+            }
+
+    util-deprecate@1.0.2:
+        resolution:
+            {
+                integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+            }
+
+    v8-to-istanbul@9.3.0:
+        resolution:
+            {
+                integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==,
+            }
+        engines: { node: '>=10.12.0' }
+
+    walker@1.0.8:
+        resolution:
+            {
+                integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==,
+            }
+
+    which@1.3.1:
+        resolution:
+            {
+                integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==,
+            }
+        hasBin: true
+
+    which@2.0.2:
+        resolution:
+            {
+                integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+            }
+        engines: { node: '>= 8' }
+        hasBin: true
+
+    word-wrap@1.2.5:
+        resolution:
+            {
+                integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
+            }
+        engines: { node: '>=0.10.0' }
+
+    wrap-ansi@7.0.0:
+        resolution:
+            {
+                integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+            }
+        engines: { node: '>=10' }
+
+    wrappy@1.0.2:
+        resolution:
+            {
+                integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+            }
+
+    write-file-atomic@4.0.2:
+        resolution:
+            {
+                integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==,
+            }
+        engines: { node: ^12.13.0 || ^14.15.0 || >=16.0.0 }
+
+    write-file-atomic@5.0.1:
+        resolution:
+            {
+                integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==,
+            }
+        engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
+
+    y18n@5.0.8:
+        resolution:
+            {
+                integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
+            }
+        engines: { node: '>=10' }
+
+    yallist@3.1.1:
+        resolution:
+            {
+                integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
+            }
+
+    yargs-parser@21.1.1:
+        resolution:
+            {
+                integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
+            }
+        engines: { node: '>=12' }
+
+    yargs@17.7.2:
+        resolution:
+            {
+                integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==,
+            }
+        engines: { node: '>=12' }
+
+    yocto-queue@0.1.0:
+        resolution:
+            {
+                integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
+            }
+        engines: { node: '>=10' }
+
+snapshots:
+    '@babel/code-frame@7.29.0':
+        dependencies:
+            '@babel/helper-validator-identifier': 7.28.5
+            js-tokens: 4.0.0
+            picocolors: 1.1.1
+
+    '@babel/compat-data@7.29.0': {}
+
+    '@babel/core@7.29.0':
+        dependencies:
+            '@babel/code-frame': 7.29.0
+            '@babel/generator': 7.29.1
+            '@babel/helper-compilation-targets': 7.28.6
+            '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+            '@babel/helpers': 7.29.2
+            '@babel/parser': 7.29.2
+            '@babel/template': 7.28.6
+            '@babel/traverse': 7.29.0
+            '@babel/types': 7.29.0
+            '@jridgewell/remapping': 2.3.5
+            convert-source-map: 2.0.0
+            debug: 4.4.3
+            gensync: 1.0.0-beta.2
+            json5: 2.2.3
+            semver: 6.3.1
+        transitivePeerDependencies:
+            - supports-color
+
+    '@babel/generator@7.29.1':
+        dependencies:
+            '@babel/parser': 7.29.2
+            '@babel/types': 7.29.0
+            '@jridgewell/gen-mapping': 0.3.13
+            '@jridgewell/trace-mapping': 0.3.31
+            jsesc: 3.1.0
+
+    '@babel/helper-compilation-targets@7.28.6':
+        dependencies:
+            '@babel/compat-data': 7.29.0
+            '@babel/helper-validator-option': 7.27.1
+            browserslist: 4.28.1
+            lru-cache: 5.1.1
+            semver: 6.3.1
+
+    '@babel/helper-globals@7.28.0': {}
+
+    '@babel/helper-module-imports@7.28.6':
+        dependencies:
+            '@babel/traverse': 7.29.0
+            '@babel/types': 7.29.0
+        transitivePeerDependencies:
+            - supports-color
+
+    '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-module-imports': 7.28.6
+            '@babel/helper-validator-identifier': 7.28.5
+            '@babel/traverse': 7.29.0
+        transitivePeerDependencies:
+            - supports-color
+
+    '@babel/helper-plugin-utils@7.28.6': {}
+
+    '@babel/helper-string-parser@7.27.1': {}
+
+    '@babel/helper-validator-identifier@7.28.5': {}
+
+    '@babel/helper-validator-option@7.27.1': {}
+
+    '@babel/helpers@7.29.2':
+        dependencies:
+            '@babel/template': 7.28.6
+            '@babel/types': 7.29.0
+
+    '@babel/parser@7.29.2':
+        dependencies:
+            '@babel/types': 7.29.0
+
+    '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/helper-plugin-utils': 7.28.6
+
+    '@babel/template@7.28.6':
+        dependencies:
+            '@babel/code-frame': 7.29.0
+            '@babel/parser': 7.29.2
+            '@babel/types': 7.29.0
+
+    '@babel/traverse@7.29.0':
+        dependencies:
+            '@babel/code-frame': 7.29.0
+            '@babel/generator': 7.29.1
+            '@babel/helper-globals': 7.28.0
+            '@babel/parser': 7.29.2
+            '@babel/template': 7.28.6
+            '@babel/types': 7.29.0
+            debug: 4.4.3
+        transitivePeerDependencies:
+            - supports-color
+
+    '@babel/types@7.29.0':
+        dependencies:
+            '@babel/helper-string-parser': 7.27.1
+            '@babel/helper-validator-identifier': 7.28.5
+
+    '@bcoe/v8-coverage@0.2.3': {}
+
+    '@cacheable/memory@2.0.8':
+        dependencies:
+            '@cacheable/utils': 2.4.0
+            '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+            hookified: 1.15.1
+            keyv: 5.6.0
+
+    '@cacheable/utils@2.4.0':
+        dependencies:
+            hashery: 1.5.0
+            keyv: 5.6.0
+
+    '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+        dependencies:
+            '@csstools/css-tokenizer': 3.0.4
+
+    '@csstools/css-syntax-patches-for-csstree@1.1.1(css-tree@3.2.1)':
+        optionalDependencies:
+            css-tree: 3.2.1
+
+    '@csstools/css-tokenizer@3.0.4': {}
+
+    '@csstools/media-query-list-parser@4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+        dependencies:
+            '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+            '@csstools/css-tokenizer': 3.0.4
+
+    '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.1)':
+        dependencies:
+            postcss-selector-parser: 7.1.1
+
+    '@dual-bundle/import-meta-resolve@4.2.1': {}
+
+    '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+        dependencies:
+            eslint: 9.39.4
+            eslint-visitor-keys: 3.4.3
+
+    '@eslint-community/regexpp@4.12.2': {}
+
+    '@eslint/config-array@0.21.2':
+        dependencies:
+            '@eslint/object-schema': 2.1.7
+            debug: 4.4.3
+            minimatch: 3.1.5
+        transitivePeerDependencies:
+            - supports-color
+
+    '@eslint/config-helpers@0.4.2':
+        dependencies:
+            '@eslint/core': 0.17.0
+
+    '@eslint/core@0.17.0':
+        dependencies:
+            '@types/json-schema': 7.0.15
+
+    '@eslint/eslintrc@3.3.5':
+        dependencies:
+            ajv: 6.14.0
+            debug: 4.4.3
+            espree: 10.4.0
+            globals: 14.0.0
+            ignore: 5.3.2
+            import-fresh: 3.3.1
+            js-yaml: 4.1.1
+            minimatch: 3.1.5
+            strip-json-comments: 3.1.1
+        transitivePeerDependencies:
+            - supports-color
+
+    '@eslint/js@9.39.4': {}
+
+    '@eslint/object-schema@2.1.7': {}
+
+    '@eslint/plugin-kit@0.4.1':
+        dependencies:
+            '@eslint/core': 0.17.0
+            levn: 0.4.1
+
+    '@humanfs/core@0.19.1': {}
+
+    '@humanfs/node@0.16.7':
+        dependencies:
+            '@humanfs/core': 0.19.1
+            '@humanwhocodes/retry': 0.4.3
+
+    '@humanwhocodes/module-importer@1.0.1': {}
+
+    '@humanwhocodes/retry@0.4.3': {}
+
+    '@istanbuljs/load-nyc-config@1.1.0':
+        dependencies:
+            camelcase: 5.3.1
+            find-up: 4.1.0
+            get-package-type: 0.1.0
+            js-yaml: 3.14.2
+            resolve-from: 5.0.0
+
+    '@istanbuljs/schema@0.1.3': {}
+
+    '@jest/console@29.7.0':
+        dependencies:
+            '@jest/types': 29.6.3
+            '@types/node': 25.5.0
+            chalk: 4.1.2
+            jest-message-util: 29.7.0
+            jest-util: 29.7.0
+            slash: 3.0.0
+
+    '@jest/core@29.7.0':
+        dependencies:
+            '@jest/console': 29.7.0
+            '@jest/reporters': 29.7.0
+            '@jest/test-result': 29.7.0
+            '@jest/transform': 29.7.0
+            '@jest/types': 29.6.3
+            '@types/node': 25.5.0
+            ansi-escapes: 4.3.2
+            chalk: 4.1.2
+            ci-info: 3.9.0
+            exit: 0.1.2
+            graceful-fs: 4.2.11
+            jest-changed-files: 29.7.0
+            jest-config: 29.7.0(@types/node@25.5.0)
+            jest-haste-map: 29.7.0
+            jest-message-util: 29.7.0
+            jest-regex-util: 29.6.3
+            jest-resolve: 29.7.0
+            jest-resolve-dependencies: 29.7.0
+            jest-runner: 29.7.0
+            jest-runtime: 29.7.0
+            jest-snapshot: 29.7.0
+            jest-util: 29.7.0
+            jest-validate: 29.7.0
+            jest-watcher: 29.7.0
+            micromatch: 4.0.8
+            pretty-format: 29.7.0
+            slash: 3.0.0
+            strip-ansi: 6.0.1
+        transitivePeerDependencies:
+            - babel-plugin-macros
+            - supports-color
+            - ts-node
+
+    '@jest/environment@29.7.0':
+        dependencies:
+            '@jest/fake-timers': 29.7.0
+            '@jest/types': 29.6.3
+            '@types/node': 25.5.0
+            jest-mock: 29.7.0
+
+    '@jest/expect-utils@29.7.0':
+        dependencies:
+            jest-get-type: 29.6.3
+
+    '@jest/expect@29.7.0':
+        dependencies:
+            expect: 29.7.0
+            jest-snapshot: 29.7.0
+        transitivePeerDependencies:
+            - supports-color
+
+    '@jest/fake-timers@29.7.0':
+        dependencies:
+            '@jest/types': 29.6.3
+            '@sinonjs/fake-timers': 10.3.0
+            '@types/node': 25.5.0
+            jest-message-util: 29.7.0
+            jest-mock: 29.7.0
+            jest-util: 29.7.0
+
+    '@jest/globals@29.7.0':
+        dependencies:
+            '@jest/environment': 29.7.0
+            '@jest/expect': 29.7.0
+            '@jest/types': 29.6.3
+            jest-mock: 29.7.0
+        transitivePeerDependencies:
+            - supports-color
+
+    '@jest/reporters@29.7.0':
+        dependencies:
+            '@bcoe/v8-coverage': 0.2.3
+            '@jest/console': 29.7.0
+            '@jest/test-result': 29.7.0
+            '@jest/transform': 29.7.0
+            '@jest/types': 29.6.3
+            '@jridgewell/trace-mapping': 0.3.31
+            '@types/node': 25.5.0
+            chalk: 4.1.2
+            collect-v8-coverage: 1.0.3
+            exit: 0.1.2
+            glob: 7.2.3
+            graceful-fs: 4.2.11
+            istanbul-lib-coverage: 3.2.2
+            istanbul-lib-instrument: 6.0.3
+            istanbul-lib-report: 3.0.1
+            istanbul-lib-source-maps: 4.0.1
+            istanbul-reports: 3.2.0
+            jest-message-util: 29.7.0
+            jest-util: 29.7.0
+            jest-worker: 29.7.0
+            slash: 3.0.0
+            string-length: 4.0.2
+            strip-ansi: 6.0.1
+            v8-to-istanbul: 9.3.0
+        transitivePeerDependencies:
+            - supports-color
+
+    '@jest/schemas@29.6.3':
+        dependencies:
+            '@sinclair/typebox': 0.27.10
+
+    '@jest/source-map@29.6.3':
+        dependencies:
+            '@jridgewell/trace-mapping': 0.3.31
+            callsites: 3.1.0
+            graceful-fs: 4.2.11
+
+    '@jest/test-result@29.7.0':
+        dependencies:
+            '@jest/console': 29.7.0
+            '@jest/types': 29.6.3
+            '@types/istanbul-lib-coverage': 2.0.6
+            collect-v8-coverage: 1.0.3
+
+    '@jest/test-sequencer@29.7.0':
+        dependencies:
+            '@jest/test-result': 29.7.0
+            graceful-fs: 4.2.11
+            jest-haste-map: 29.7.0
+            slash: 3.0.0
+
+    '@jest/transform@29.7.0':
+        dependencies:
+            '@babel/core': 7.29.0
+            '@jest/types': 29.6.3
+            '@jridgewell/trace-mapping': 0.3.31
+            babel-plugin-istanbul: 6.1.1
+            chalk: 4.1.2
+            convert-source-map: 2.0.0
+            fast-json-stable-stringify: 2.1.0
+            graceful-fs: 4.2.11
+            jest-haste-map: 29.7.0
+            jest-regex-util: 29.6.3
+            jest-util: 29.7.0
+            micromatch: 4.0.8
+            pirates: 4.0.7
+            slash: 3.0.0
+            write-file-atomic: 4.0.2
+        transitivePeerDependencies:
+            - supports-color
+
+    '@jest/types@29.6.3':
+        dependencies:
+            '@jest/schemas': 29.6.3
+            '@types/istanbul-lib-coverage': 2.0.6
+            '@types/istanbul-reports': 3.0.4
+            '@types/node': 25.5.0
+            '@types/yargs': 17.0.35
+            chalk: 4.1.2
+
+    '@jridgewell/gen-mapping@0.3.13':
+        dependencies:
+            '@jridgewell/sourcemap-codec': 1.5.5
+            '@jridgewell/trace-mapping': 0.3.31
+
+    '@jridgewell/remapping@2.3.5':
+        dependencies:
+            '@jridgewell/gen-mapping': 0.3.13
+            '@jridgewell/trace-mapping': 0.3.31
+
+    '@jridgewell/resolve-uri@3.1.2': {}
+
+    '@jridgewell/sourcemap-codec@1.5.5': {}
+
+    '@jridgewell/trace-mapping@0.3.31':
+        dependencies:
+            '@jridgewell/resolve-uri': 3.1.2
+            '@jridgewell/sourcemap-codec': 1.5.5
+
+    '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+        dependencies:
+            hashery: 1.5.0
+            hookified: 1.15.1
+            keyv: 5.6.0
+
+    '@keyv/serialize@1.1.1': {}
+
+    '@nodelib/fs.scandir@2.1.5':
+        dependencies:
+            '@nodelib/fs.stat': 2.0.5
+            run-parallel: 1.2.0
+
+    '@nodelib/fs.stat@2.0.5': {}
+
+    '@nodelib/fs.walk@1.2.8':
+        dependencies:
+            '@nodelib/fs.scandir': 2.1.5
+            fastq: 1.20.1
+
+    '@sinclair/typebox@0.27.10': {}
+
+    '@sinonjs/commons@3.0.1':
+        dependencies:
+            type-detect: 4.0.8
+
+    '@sinonjs/fake-timers@10.3.0':
+        dependencies:
+            '@sinonjs/commons': 3.0.1
+
+    '@stylistic/stylelint-plugin@4.0.1(stylelint@16.26.1)':
+        dependencies:
+            '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+            '@csstools/css-tokenizer': 3.0.4
+            '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+            postcss: 8.5.8
+            postcss-selector-parser: 7.1.1
+            postcss-value-parser: 4.2.0
+            style-search: 0.1.0
+            stylelint: 16.26.1
+
+    '@types/babel__core@7.20.5':
+        dependencies:
+            '@babel/parser': 7.29.2
+            '@babel/types': 7.29.0
+            '@types/babel__generator': 7.27.0
+            '@types/babel__template': 7.4.4
+            '@types/babel__traverse': 7.28.0
+
+    '@types/babel__generator@7.27.0':
+        dependencies:
+            '@babel/types': 7.29.0
+
+    '@types/babel__template@7.4.4':
+        dependencies:
+            '@babel/parser': 7.29.2
+            '@babel/types': 7.29.0
+
+    '@types/babel__traverse@7.28.0':
+        dependencies:
+            '@babel/types': 7.29.0
+
+    '@types/estree@1.0.8': {}
+
+    '@types/graceful-fs@4.1.9':
+        dependencies:
+            '@types/node': 25.5.0
+
+    '@types/istanbul-lib-coverage@2.0.6': {}
+
+    '@types/istanbul-lib-report@3.0.3':
+        dependencies:
+            '@types/istanbul-lib-coverage': 2.0.6
+
+    '@types/istanbul-reports@3.0.4':
+        dependencies:
+            '@types/istanbul-lib-report': 3.0.3
+
+    '@types/json-schema@7.0.15': {}
+
+    '@types/node@25.5.0':
+        dependencies:
+            undici-types: 7.18.2
+
+    '@types/stack-utils@2.0.3': {}
+
+    '@types/yargs-parser@21.0.3': {}
+
+    '@types/yargs@17.0.35':
+        dependencies:
+            '@types/yargs-parser': 21.0.3
+
+    acorn-jsx@5.3.2(acorn@8.16.0):
+        dependencies:
+            acorn: 8.16.0
+
+    acorn@8.16.0: {}
+
+    ajv@6.14.0:
+        dependencies:
+            fast-deep-equal: 3.1.3
+            fast-json-stable-stringify: 2.1.0
+            json-schema-traverse: 0.4.1
+            uri-js: 4.4.1
+
+    ajv@8.18.0:
+        dependencies:
+            fast-deep-equal: 3.1.3
+            fast-uri: 3.1.0
+            json-schema-traverse: 1.0.0
+            require-from-string: 2.0.2
+
+    ansi-escapes@4.3.2:
+        dependencies:
+            type-fest: 0.21.3
+
+    ansi-regex@5.0.1: {}
+
+    ansi-styles@4.3.0:
+        dependencies:
+            color-convert: 2.0.1
+
+    ansi-styles@5.2.0: {}
+
+    anymatch@3.1.3:
+        dependencies:
+            normalize-path: 3.0.0
+            picomatch: 2.3.1
+
+    argparse@1.0.10:
+        dependencies:
+            sprintf-js: 1.0.3
+
+    argparse@2.0.1: {}
+
+    array-union@2.1.0: {}
+
+    astral-regex@2.0.0: {}
+
+    babel-jest@29.7.0(@babel/core@7.29.0):
+        dependencies:
+            '@babel/core': 7.29.0
+            '@jest/transform': 29.7.0
+            '@types/babel__core': 7.20.5
+            babel-plugin-istanbul: 6.1.1
+            babel-preset-jest: 29.6.3(@babel/core@7.29.0)
+            chalk: 4.1.2
+            graceful-fs: 4.2.11
+            slash: 3.0.0
+        transitivePeerDependencies:
+            - supports-color
+
+    babel-plugin-istanbul@6.1.1:
+        dependencies:
+            '@babel/helper-plugin-utils': 7.28.6
+            '@istanbuljs/load-nyc-config': 1.1.0
+            '@istanbuljs/schema': 0.1.3
+            istanbul-lib-instrument: 5.2.1
+            test-exclude: 6.0.0
+        transitivePeerDependencies:
+            - supports-color
+
+    babel-plugin-jest-hoist@29.6.3:
+        dependencies:
+            '@babel/template': 7.28.6
+            '@babel/types': 7.29.0
+            '@types/babel__core': 7.20.5
+            '@types/babel__traverse': 7.28.0
+
+    babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
+            '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
+            '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
+            '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
+            '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+            '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+            '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
+            '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
+            '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
+            '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
+            '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
+            '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
+            '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
+            '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
+            '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
+
+    babel-preset-jest@29.6.3(@babel/core@7.29.0):
+        dependencies:
+            '@babel/core': 7.29.0
+            babel-plugin-jest-hoist: 29.6.3
+            babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+
+    balanced-match@1.0.2: {}
+
+    balanced-match@2.0.0: {}
+
+    baseline-browser-mapping@2.10.8: {}
+
+    brace-expansion@1.1.12:
+        dependencies:
+            balanced-match: 1.0.2
+            concat-map: 0.0.1
+
+    braces@3.0.3:
+        dependencies:
+            fill-range: 7.1.1
+
+    browserslist@4.28.1:
+        dependencies:
+            baseline-browser-mapping: 2.10.8
+            caniuse-lite: 1.0.30001780
+            electron-to-chromium: 1.5.313
+            node-releases: 2.0.36
+            update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+    bser@2.1.1:
+        dependencies:
+            node-int64: 0.4.0
+
+    buffer-from@1.1.2: {}
+
+    cacheable@2.3.3:
+        dependencies:
+            '@cacheable/memory': 2.0.8
+            '@cacheable/utils': 2.4.0
+            hookified: 1.15.1
+            keyv: 5.6.0
+            qified: 0.6.0
+
+    callsites@3.1.0: {}
+
+    camelcase@5.3.1: {}
+
+    camelcase@6.3.0: {}
+
+    caniuse-lite@1.0.30001780: {}
+
+    chalk@4.1.2:
+        dependencies:
+            ansi-styles: 4.3.0
+            supports-color: 7.2.0
+
+    char-regex@1.0.2: {}
+
+    ci-info@3.9.0: {}
+
+    cjs-module-lexer@1.4.3: {}
+
+    cliui@8.0.1:
+        dependencies:
+            string-width: 4.2.3
+            strip-ansi: 6.0.1
+            wrap-ansi: 7.0.0
+
+    co@4.6.0: {}
+
+    collect-v8-coverage@1.0.3: {}
+
+    color-convert@2.0.1:
+        dependencies:
+            color-name: 1.1.4
+
+    color-name@1.1.4: {}
+
+    colord@2.9.3: {}
+
+    concat-map@0.0.1: {}
+
+    convert-source-map@2.0.0: {}
+
+    cosmiconfig@9.0.1:
+        dependencies:
+            env-paths: 2.2.1
+            import-fresh: 3.3.1
+            js-yaml: 4.1.1
+            parse-json: 5.2.0
+
+    create-jest@29.7.0(@types/node@25.5.0):
+        dependencies:
+            '@jest/types': 29.6.3
+            chalk: 4.1.2
+            exit: 0.1.2
+            graceful-fs: 4.2.11
+            jest-config: 29.7.0(@types/node@25.5.0)
+            jest-util: 29.7.0
+            prompts: 2.4.2
+        transitivePeerDependencies:
+            - '@types/node'
+            - babel-plugin-macros
+            - supports-color
+            - ts-node
+
+    cross-spawn@7.0.6:
+        dependencies:
+            path-key: 3.1.1
+            shebang-command: 2.0.0
+            which: 2.0.2
+
+    css-functions-list@3.3.3: {}
+
+    css-tree@3.2.1:
+        dependencies:
+            mdn-data: 2.27.1
+            source-map-js: 1.2.1
+
+    cssesc@3.0.0: {}
+
+    debug@4.4.3:
+        dependencies:
+            ms: 2.1.3
+
+    dedent@1.7.2: {}
+
+    deep-is@0.1.4: {}
+
+    deepmerge@4.3.1: {}
+
+    detect-newline@3.1.0: {}
+
+    diff-sequences@29.6.3: {}
+
+    dir-glob@3.0.1:
+        dependencies:
+            path-type: 4.0.0
+
+    electron-to-chromium@1.5.313: {}
+
+    emittery@0.13.1: {}
+
+    emoji-regex@8.0.0: {}
+
+    env-paths@2.2.1: {}
+
+    error-ex@1.3.4:
+        dependencies:
+            is-arrayish: 0.2.1
+
+    escalade@3.2.0: {}
+
+    escape-string-regexp@2.0.0: {}
+
+    escape-string-regexp@4.0.0: {}
+
+    eslint-scope@8.4.0:
+        dependencies:
+            esrecurse: 4.3.0
+            estraverse: 5.3.0
+
+    eslint-visitor-keys@3.4.3: {}
+
+    eslint-visitor-keys@4.2.1: {}
+
+    eslint@9.39.4:
+        dependencies:
+            '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+            '@eslint-community/regexpp': 4.12.2
+            '@eslint/config-array': 0.21.2
+            '@eslint/config-helpers': 0.4.2
+            '@eslint/core': 0.17.0
+            '@eslint/eslintrc': 3.3.5
+            '@eslint/js': 9.39.4
+            '@eslint/plugin-kit': 0.4.1
+            '@humanfs/node': 0.16.7
+            '@humanwhocodes/module-importer': 1.0.1
+            '@humanwhocodes/retry': 0.4.3
+            '@types/estree': 1.0.8
+            ajv: 6.14.0
+            chalk: 4.1.2
+            cross-spawn: 7.0.6
+            debug: 4.4.3
+            escape-string-regexp: 4.0.0
+            eslint-scope: 8.4.0
+            eslint-visitor-keys: 4.2.1
+            espree: 10.4.0
+            esquery: 1.7.0
+            esutils: 2.0.3
+            fast-deep-equal: 3.1.3
+            file-entry-cache: 8.0.0
+            find-up: 5.0.0
+            glob-parent: 6.0.2
+            ignore: 5.3.2
+            imurmurhash: 0.1.4
+            is-glob: 4.0.3
+            json-stable-stringify-without-jsonify: 1.0.1
+            lodash.merge: 4.6.2
+            minimatch: 3.1.5
+            natural-compare: 1.4.0
+            optionator: 0.9.4
+        transitivePeerDependencies:
+            - supports-color
+
+    espree@10.4.0:
+        dependencies:
+            acorn: 8.16.0
+            acorn-jsx: 5.3.2(acorn@8.16.0)
+            eslint-visitor-keys: 4.2.1
+
+    esprima@4.0.1: {}
+
+    esquery@1.7.0:
+        dependencies:
+            estraverse: 5.3.0
+
+    esrecurse@4.3.0:
+        dependencies:
+            estraverse: 5.3.0
+
+    estraverse@5.3.0: {}
+
+    esutils@2.0.3: {}
+
+    execa@5.1.1:
+        dependencies:
+            cross-spawn: 7.0.6
+            get-stream: 6.0.1
+            human-signals: 2.1.0
+            is-stream: 2.0.1
+            merge-stream: 2.0.0
+            npm-run-path: 4.0.1
+            onetime: 5.1.2
+            signal-exit: 3.0.7
+            strip-final-newline: 2.0.0
+
+    exit@0.1.2: {}
+
+    expect@29.7.0:
+        dependencies:
+            '@jest/expect-utils': 29.7.0
+            jest-get-type: 29.6.3
+            jest-matcher-utils: 29.7.0
+            jest-message-util: 29.7.0
+            jest-util: 29.7.0
+
+    fast-deep-equal@3.1.3: {}
+
+    fast-glob@3.3.3:
+        dependencies:
+            '@nodelib/fs.stat': 2.0.5
+            '@nodelib/fs.walk': 1.2.8
+            glob-parent: 5.1.2
+            merge2: 1.4.1
+            micromatch: 4.0.8
+
+    fast-json-stable-stringify@2.1.0: {}
+
+    fast-levenshtein@2.0.6: {}
+
+    fast-uri@3.1.0: {}
+
+    fastest-levenshtein@1.0.16: {}
+
+    fastq@1.20.1:
+        dependencies:
+            reusify: 1.1.0
+
+    fb-watchman@2.0.2:
+        dependencies:
+            bser: 2.1.1
+
+    file-entry-cache@11.1.2:
+        dependencies:
+            flat-cache: 6.1.20
+
+    file-entry-cache@8.0.0:
+        dependencies:
+            flat-cache: 4.0.1
+
+    fill-range@7.1.1:
+        dependencies:
+            to-regex-range: 5.0.1
+
+    find-up@4.1.0:
+        dependencies:
+            locate-path: 5.0.0
+            path-exists: 4.0.0
+
+    find-up@5.0.0:
+        dependencies:
+            locate-path: 6.0.0
+            path-exists: 4.0.0
+
+    flat-cache@4.0.1:
+        dependencies:
+            flatted: 3.4.2
+            keyv: 4.5.4
+
+    flat-cache@6.1.20:
+        dependencies:
+            cacheable: 2.3.3
+            flatted: 3.4.2
+            hookified: 1.15.1
+
+    flatted@3.4.2: {}
+
+    fs.realpath@1.0.0: {}
+
+    fsevents@2.3.3:
+        optional: true
+
+    function-bind@1.1.2: {}
+
+    gensync@1.0.0-beta.2: {}
+
+    get-caller-file@2.0.5: {}
+
+    get-package-type@0.1.0: {}
+
+    get-stream@6.0.1: {}
+
+    glob-parent@5.1.2:
+        dependencies:
+            is-glob: 4.0.3
+
+    glob-parent@6.0.2:
+        dependencies:
+            is-glob: 4.0.3
+
+    glob@7.2.3:
+        dependencies:
+            fs.realpath: 1.0.0
+            inflight: 1.0.6
+            inherits: 2.0.4
+            minimatch: 3.1.5
+            once: 1.4.0
+            path-is-absolute: 1.0.1
+
+    global-modules@2.0.0:
+        dependencies:
+            global-prefix: 3.0.0
+
+    global-prefix@3.0.0:
+        dependencies:
+            ini: 1.3.8
+            kind-of: 6.0.3
+            which: 1.3.1
+
+    globals@14.0.0: {}
+
+    globby@11.1.0:
+        dependencies:
+            array-union: 2.1.0
+            dir-glob: 3.0.1
+            fast-glob: 3.3.3
+            ignore: 5.3.2
+            merge2: 1.4.1
+            slash: 3.0.0
+
+    globjoin@0.1.4: {}
+
+    graceful-fs@4.2.11: {}
+
+    has-flag@4.0.0: {}
+
+    hashery@1.5.0:
+        dependencies:
+            hookified: 1.15.1
+
+    hasown@2.0.2:
+        dependencies:
+            function-bind: 1.1.2
+
+    hookified@1.15.1: {}
+
+    html-escaper@2.0.2: {}
+
+    html-tags@3.3.1: {}
+
+    human-signals@2.1.0: {}
+
+    ignore@5.3.2: {}
+
+    ignore@7.0.5: {}
+
+    import-fresh@3.3.1:
+        dependencies:
+            parent-module: 1.0.1
+            resolve-from: 4.0.0
+
+    import-local@3.2.0:
+        dependencies:
+            pkg-dir: 4.2.0
+            resolve-cwd: 3.0.0
+
+    imurmurhash@0.1.4: {}
+
+    inflight@1.0.6:
+        dependencies:
+            once: 1.4.0
+            wrappy: 1.0.2
+
+    inherits@2.0.4: {}
+
+    ini@1.3.8: {}
+
+    is-arrayish@0.2.1: {}
+
+    is-core-module@2.16.1:
+        dependencies:
+            hasown: 2.0.2
+
+    is-extglob@2.1.1: {}
+
+    is-fullwidth-code-point@3.0.0: {}
+
+    is-generator-fn@2.1.0: {}
+
+    is-glob@4.0.3:
+        dependencies:
+            is-extglob: 2.1.1
+
+    is-number@7.0.0: {}
+
+    is-plain-object@5.0.0: {}
+
+    is-stream@2.0.1: {}
+
+    isexe@2.0.0: {}
+
+    istanbul-lib-coverage@3.2.2: {}
+
+    istanbul-lib-instrument@5.2.1:
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/parser': 7.29.2
+            '@istanbuljs/schema': 0.1.3
+            istanbul-lib-coverage: 3.2.2
+            semver: 6.3.1
+        transitivePeerDependencies:
+            - supports-color
+
+    istanbul-lib-instrument@6.0.3:
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/parser': 7.29.2
+            '@istanbuljs/schema': 0.1.3
+            istanbul-lib-coverage: 3.2.2
+            semver: 7.7.4
+        transitivePeerDependencies:
+            - supports-color
+
+    istanbul-lib-report@3.0.1:
+        dependencies:
+            istanbul-lib-coverage: 3.2.2
+            make-dir: 4.0.0
+            supports-color: 7.2.0
+
+    istanbul-lib-source-maps@4.0.1:
+        dependencies:
+            debug: 4.4.3
+            istanbul-lib-coverage: 3.2.2
+            source-map: 0.6.1
+        transitivePeerDependencies:
+            - supports-color
+
+    istanbul-reports@3.2.0:
+        dependencies:
+            html-escaper: 2.0.2
+            istanbul-lib-report: 3.0.1
+
+    jest-changed-files@29.7.0:
+        dependencies:
+            execa: 5.1.1
+            jest-util: 29.7.0
+            p-limit: 3.1.0
+
+    jest-circus@29.7.0:
+        dependencies:
+            '@jest/environment': 29.7.0
+            '@jest/expect': 29.7.0
+            '@jest/test-result': 29.7.0
+            '@jest/types': 29.6.3
+            '@types/node': 25.5.0
+            chalk: 4.1.2
+            co: 4.6.0
+            dedent: 1.7.2
+            is-generator-fn: 2.1.0
+            jest-each: 29.7.0
+            jest-matcher-utils: 29.7.0
+            jest-message-util: 29.7.0
+            jest-runtime: 29.7.0
+            jest-snapshot: 29.7.0
+            jest-util: 29.7.0
+            p-limit: 3.1.0
+            pretty-format: 29.7.0
+            pure-rand: 6.1.0
+            slash: 3.0.0
+            stack-utils: 2.0.6
+        transitivePeerDependencies:
+            - babel-plugin-macros
+            - supports-color
+
+    jest-cli@29.7.0(@types/node@25.5.0):
+        dependencies:
+            '@jest/core': 29.7.0
+            '@jest/test-result': 29.7.0
+            '@jest/types': 29.6.3
+            chalk: 4.1.2
+            create-jest: 29.7.0(@types/node@25.5.0)
+            exit: 0.1.2
+            import-local: 3.2.0
+            jest-config: 29.7.0(@types/node@25.5.0)
+            jest-util: 29.7.0
+            jest-validate: 29.7.0
+            yargs: 17.7.2
+        transitivePeerDependencies:
+            - '@types/node'
+            - babel-plugin-macros
+            - supports-color
+            - ts-node
+
+    jest-config@29.7.0(@types/node@25.5.0):
+        dependencies:
+            '@babel/core': 7.29.0
+            '@jest/test-sequencer': 29.7.0
+            '@jest/types': 29.6.3
+            babel-jest: 29.7.0(@babel/core@7.29.0)
+            chalk: 4.1.2
+            ci-info: 3.9.0
+            deepmerge: 4.3.1
+            glob: 7.2.3
+            graceful-fs: 4.2.11
+            jest-circus: 29.7.0
+            jest-environment-node: 29.7.0
+            jest-get-type: 29.6.3
+            jest-regex-util: 29.6.3
+            jest-resolve: 29.7.0
+            jest-runner: 29.7.0
+            jest-util: 29.7.0
+            jest-validate: 29.7.0
+            micromatch: 4.0.8
+            parse-json: 5.2.0
+            pretty-format: 29.7.0
+            slash: 3.0.0
+            strip-json-comments: 3.1.1
+        optionalDependencies:
+            '@types/node': 25.5.0
+        transitivePeerDependencies:
+            - babel-plugin-macros
+            - supports-color
+
+    jest-diff@29.7.0:
+        dependencies:
+            chalk: 4.1.2
+            diff-sequences: 29.6.3
+            jest-get-type: 29.6.3
+            pretty-format: 29.7.0
+
+    jest-docblock@29.7.0:
+        dependencies:
+            detect-newline: 3.1.0
+
+    jest-each@29.7.0:
+        dependencies:
+            '@jest/types': 29.6.3
+            chalk: 4.1.2
+            jest-get-type: 29.6.3
+            jest-util: 29.7.0
+            pretty-format: 29.7.0
+
+    jest-environment-node@29.7.0:
+        dependencies:
+            '@jest/environment': 29.7.0
+            '@jest/fake-timers': 29.7.0
+            '@jest/types': 29.6.3
+            '@types/node': 25.5.0
+            jest-mock: 29.7.0
+            jest-util: 29.7.0
+
+    jest-get-type@29.6.3: {}
+
+    jest-haste-map@29.7.0:
+        dependencies:
+            '@jest/types': 29.6.3
+            '@types/graceful-fs': 4.1.9
+            '@types/node': 25.5.0
+            anymatch: 3.1.3
+            fb-watchman: 2.0.2
+            graceful-fs: 4.2.11
+            jest-regex-util: 29.6.3
+            jest-util: 29.7.0
+            jest-worker: 29.7.0
+            micromatch: 4.0.8
+            walker: 1.0.8
+        optionalDependencies:
+            fsevents: 2.3.3
+
+    jest-leak-detector@29.7.0:
+        dependencies:
+            jest-get-type: 29.6.3
+            pretty-format: 29.7.0
+
+    jest-matcher-utils@29.7.0:
+        dependencies:
+            chalk: 4.1.2
+            jest-diff: 29.7.0
+            jest-get-type: 29.6.3
+            pretty-format: 29.7.0
+
+    jest-message-util@29.7.0:
+        dependencies:
+            '@babel/code-frame': 7.29.0
+            '@jest/types': 29.6.3
+            '@types/stack-utils': 2.0.3
+            chalk: 4.1.2
+            graceful-fs: 4.2.11
+            micromatch: 4.0.8
+            pretty-format: 29.7.0
+            slash: 3.0.0
+            stack-utils: 2.0.6
+
+    jest-mock@29.7.0:
+        dependencies:
+            '@jest/types': 29.6.3
+            '@types/node': 25.5.0
+            jest-util: 29.7.0
+
+    jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+        optionalDependencies:
+            jest-resolve: 29.7.0
+
+    jest-regex-util@29.6.3: {}
+
+    jest-resolve-dependencies@29.7.0:
+        dependencies:
+            jest-regex-util: 29.6.3
+            jest-snapshot: 29.7.0
+        transitivePeerDependencies:
+            - supports-color
+
+    jest-resolve@29.7.0:
+        dependencies:
+            chalk: 4.1.2
+            graceful-fs: 4.2.11
+            jest-haste-map: 29.7.0
+            jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
+            jest-util: 29.7.0
+            jest-validate: 29.7.0
+            resolve: 1.22.11
+            resolve.exports: 2.0.3
+            slash: 3.0.0
+
+    jest-runner@29.7.0:
+        dependencies:
+            '@jest/console': 29.7.0
+            '@jest/environment': 29.7.0
+            '@jest/test-result': 29.7.0
+            '@jest/transform': 29.7.0
+            '@jest/types': 29.6.3
+            '@types/node': 25.5.0
+            chalk: 4.1.2
+            emittery: 0.13.1
+            graceful-fs: 4.2.11
+            jest-docblock: 29.7.0
+            jest-environment-node: 29.7.0
+            jest-haste-map: 29.7.0
+            jest-leak-detector: 29.7.0
+            jest-message-util: 29.7.0
+            jest-resolve: 29.7.0
+            jest-runtime: 29.7.0
+            jest-util: 29.7.0
+            jest-watcher: 29.7.0
+            jest-worker: 29.7.0
+            p-limit: 3.1.0
+            source-map-support: 0.5.13
+        transitivePeerDependencies:
+            - supports-color
+
+    jest-runtime@29.7.0:
+        dependencies:
+            '@jest/environment': 29.7.0
+            '@jest/fake-timers': 29.7.0
+            '@jest/globals': 29.7.0
+            '@jest/source-map': 29.6.3
+            '@jest/test-result': 29.7.0
+            '@jest/transform': 29.7.0
+            '@jest/types': 29.6.3
+            '@types/node': 25.5.0
+            chalk: 4.1.2
+            cjs-module-lexer: 1.4.3
+            collect-v8-coverage: 1.0.3
+            glob: 7.2.3
+            graceful-fs: 4.2.11
+            jest-haste-map: 29.7.0
+            jest-message-util: 29.7.0
+            jest-mock: 29.7.0
+            jest-regex-util: 29.6.3
+            jest-resolve: 29.7.0
+            jest-snapshot: 29.7.0
+            jest-util: 29.7.0
+            slash: 3.0.0
+            strip-bom: 4.0.0
+        transitivePeerDependencies:
+            - supports-color
+
+    jest-snapshot@29.7.0:
+        dependencies:
+            '@babel/core': 7.29.0
+            '@babel/generator': 7.29.1
+            '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+            '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+            '@babel/types': 7.29.0
+            '@jest/expect-utils': 29.7.0
+            '@jest/transform': 29.7.0
+            '@jest/types': 29.6.3
+            babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+            chalk: 4.1.2
+            expect: 29.7.0
+            graceful-fs: 4.2.11
+            jest-diff: 29.7.0
+            jest-get-type: 29.6.3
+            jest-matcher-utils: 29.7.0
+            jest-message-util: 29.7.0
+            jest-util: 29.7.0
+            natural-compare: 1.4.0
+            pretty-format: 29.7.0
+            semver: 7.7.4
+        transitivePeerDependencies:
+            - supports-color
+
+    jest-util@29.7.0:
+        dependencies:
+            '@jest/types': 29.6.3
+            '@types/node': 25.5.0
+            chalk: 4.1.2
+            ci-info: 3.9.0
+            graceful-fs: 4.2.11
+            picomatch: 2.3.1
+
+    jest-validate@29.7.0:
+        dependencies:
+            '@jest/types': 29.6.3
+            camelcase: 6.3.0
+            chalk: 4.1.2
+            jest-get-type: 29.6.3
+            leven: 3.1.0
+            pretty-format: 29.7.0
+
+    jest-watcher@29.7.0:
+        dependencies:
+            '@jest/test-result': 29.7.0
+            '@jest/types': 29.6.3
+            '@types/node': 25.5.0
+            ansi-escapes: 4.3.2
+            chalk: 4.1.2
+            emittery: 0.13.1
+            jest-util: 29.7.0
+            string-length: 4.0.2
+
+    jest-worker@29.7.0:
+        dependencies:
+            '@types/node': 25.5.0
+            jest-util: 29.7.0
+            merge-stream: 2.0.0
+            supports-color: 8.1.1
+
+    jest@29.7.0(@types/node@25.5.0):
+        dependencies:
+            '@jest/core': 29.7.0
+            '@jest/types': 29.6.3
+            import-local: 3.2.0
+            jest-cli: 29.7.0(@types/node@25.5.0)
+        transitivePeerDependencies:
+            - '@types/node'
+            - babel-plugin-macros
+            - supports-color
+            - ts-node
+
+    js-tokens@4.0.0: {}
+
+    js-yaml@3.14.2:
+        dependencies:
+            argparse: 1.0.10
+            esprima: 4.0.1
+
+    js-yaml@4.1.1:
+        dependencies:
+            argparse: 2.0.1
+
+    jsesc@3.1.0: {}
+
+    json-buffer@3.0.1: {}
+
+    json-parse-even-better-errors@2.3.1: {}
+
+    json-schema-traverse@0.4.1: {}
+
+    json-schema-traverse@1.0.0: {}
+
+    json-stable-stringify-without-jsonify@1.0.1: {}
+
+    json5@2.2.3: {}
+
+    keyv@4.5.4:
+        dependencies:
+            json-buffer: 3.0.1
+
+    keyv@5.6.0:
+        dependencies:
+            '@keyv/serialize': 1.1.1
+
+    kind-of@6.0.3: {}
+
+    kleur@3.0.3: {}
+
+    known-css-properties@0.37.0: {}
+
+    leven@3.1.0: {}
+
+    levn@0.4.1:
+        dependencies:
+            prelude-ls: 1.2.1
+            type-check: 0.4.0
+
+    lines-and-columns@1.2.4: {}
+
+    locate-path@5.0.0:
+        dependencies:
+            p-locate: 4.1.0
+
+    locate-path@6.0.0:
+        dependencies:
+            p-locate: 5.0.0
+
+    lodash.merge@4.6.2: {}
+
+    lodash.truncate@4.4.2: {}
+
+    lru-cache@5.1.1:
+        dependencies:
+            yallist: 3.1.1
+
+    make-dir@4.0.0:
+        dependencies:
+            semver: 7.7.4
+
+    makeerror@1.0.12:
+        dependencies:
+            tmpl: 1.0.5
+
+    mathml-tag-names@2.1.3: {}
+
+    mdn-data@2.27.1: {}
+
+    meow@13.2.0: {}
+
+    merge-stream@2.0.0: {}
+
+    merge2@1.4.1: {}
+
+    micromatch@4.0.8:
+        dependencies:
+            braces: 3.0.3
+            picomatch: 2.3.1
+
+    mimic-fn@2.1.0: {}
+
+    minimatch@3.1.5:
+        dependencies:
+            brace-expansion: 1.1.12
+
+    ms@2.1.3: {}
+
+    nanoid@3.3.11: {}
+
+    natural-compare@1.4.0: {}
+
+    node-int64@0.4.0: {}
+
+    node-releases@2.0.36: {}
+
+    normalize-path@3.0.0: {}
+
+    npm-run-path@4.0.1:
+        dependencies:
+            path-key: 3.1.1
+
+    once@1.4.0:
+        dependencies:
+            wrappy: 1.0.2
+
+    onetime@5.1.2:
+        dependencies:
+            mimic-fn: 2.1.0
+
+    optionator@0.9.4:
+        dependencies:
+            deep-is: 0.1.4
+            fast-levenshtein: 2.0.6
+            levn: 0.4.1
+            prelude-ls: 1.2.1
+            type-check: 0.4.0
+            word-wrap: 1.2.5
+
+    p-limit@2.3.0:
+        dependencies:
+            p-try: 2.2.0
+
+    p-limit@3.1.0:
+        dependencies:
+            yocto-queue: 0.1.0
+
+    p-locate@4.1.0:
+        dependencies:
+            p-limit: 2.3.0
+
+    p-locate@5.0.0:
+        dependencies:
+            p-limit: 3.1.0
+
+    p-try@2.2.0: {}
+
+    parent-module@1.0.1:
+        dependencies:
+            callsites: 3.1.0
+
+    parse-json@5.2.0:
+        dependencies:
+            '@babel/code-frame': 7.29.0
+            error-ex: 1.3.4
+            json-parse-even-better-errors: 2.3.1
+            lines-and-columns: 1.2.4
+
+    path-exists@4.0.0: {}
+
+    path-is-absolute@1.0.1: {}
+
+    path-key@3.1.1: {}
+
+    path-parse@1.0.7: {}
+
+    path-type@4.0.0: {}
+
+    picocolors@1.1.1: {}
+
+    picomatch@2.3.1: {}
+
+    pirates@4.0.7: {}
+
+    pkg-dir@4.2.0:
+        dependencies:
+            find-up: 4.1.0
+
+    postcss-resolve-nested-selector@0.1.6: {}
+
+    postcss-safe-parser@7.0.1(postcss@8.5.8):
+        dependencies:
+            postcss: 8.5.8
+
+    postcss-selector-parser@7.1.1:
+        dependencies:
+            cssesc: 3.0.0
+            util-deprecate: 1.0.2
+
+    postcss-value-parser@4.2.0: {}
+
+    postcss@8.5.8:
+        dependencies:
+            nanoid: 3.3.11
+            picocolors: 1.1.1
+            source-map-js: 1.2.1
+
+    prelude-ls@1.2.1: {}
+
+    prettier@3.8.1: {}
+
+    pretty-format@29.7.0:
+        dependencies:
+            '@jest/schemas': 29.6.3
+            ansi-styles: 5.2.0
+            react-is: 18.3.1
+
+    prompts@2.4.2:
+        dependencies:
+            kleur: 3.0.3
+            sisteransi: 1.0.5
+
+    punycode@2.3.1: {}
+
+    pure-rand@6.1.0: {}
+
+    qified@0.6.0:
+        dependencies:
+            hookified: 1.15.1
+
+    queue-microtask@1.2.3: {}
+
+    react-is@18.3.1: {}
+
+    require-directory@2.1.1: {}
+
+    require-from-string@2.0.2: {}
+
+    resolve-cwd@3.0.0:
+        dependencies:
+            resolve-from: 5.0.0
+
+    resolve-from@4.0.0: {}
+
+    resolve-from@5.0.0: {}
+
+    resolve.exports@2.0.3: {}
+
+    resolve@1.22.11:
+        dependencies:
+            is-core-module: 2.16.1
+            path-parse: 1.0.7
+            supports-preserve-symlinks-flag: 1.0.0
+
+    reusify@1.1.0: {}
+
+    run-parallel@1.2.0:
+        dependencies:
+            queue-microtask: 1.2.3
+
+    semver@6.3.1: {}
+
+    semver@7.7.4: {}
+
+    shebang-command@2.0.0:
+        dependencies:
+            shebang-regex: 3.0.0
+
+    shebang-regex@3.0.0: {}
+
+    signal-exit@3.0.7: {}
+
+    signal-exit@4.1.0: {}
+
+    sisteransi@1.0.5: {}
+
+    slash@3.0.0: {}
+
+    slice-ansi@4.0.0:
+        dependencies:
+            ansi-styles: 4.3.0
+            astral-regex: 2.0.0
+            is-fullwidth-code-point: 3.0.0
+
+    source-map-js@1.2.1: {}
+
+    source-map-support@0.5.13:
+        dependencies:
+            buffer-from: 1.1.2
+            source-map: 0.6.1
+
+    source-map@0.6.1: {}
+
+    sprintf-js@1.0.3: {}
+
+    stack-utils@2.0.6:
+        dependencies:
+            escape-string-regexp: 2.0.0
+
+    string-length@4.0.2:
+        dependencies:
+            char-regex: 1.0.2
+            strip-ansi: 6.0.1
+
+    string-width@4.2.3:
+        dependencies:
+            emoji-regex: 8.0.0
+            is-fullwidth-code-point: 3.0.0
+            strip-ansi: 6.0.1
+
+    strip-ansi@6.0.1:
+        dependencies:
+            ansi-regex: 5.0.1
+
+    strip-bom@4.0.0: {}
+
+    strip-final-newline@2.0.0: {}
+
+    strip-json-comments@3.1.1: {}
+
+    style-search@0.1.0: {}
+
+    stylelint@16.26.1:
+        dependencies:
+            '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+            '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
+            '@csstools/css-tokenizer': 3.0.4
+            '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+            '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
+            '@dual-bundle/import-meta-resolve': 4.2.1
+            balanced-match: 2.0.0
+            colord: 2.9.3
+            cosmiconfig: 9.0.1
+            css-functions-list: 3.3.3
+            css-tree: 3.2.1
+            debug: 4.4.3
+            fast-glob: 3.3.3
+            fastest-levenshtein: 1.0.16
+            file-entry-cache: 11.1.2
+            global-modules: 2.0.0
+            globby: 11.1.0
+            globjoin: 0.1.4
+            html-tags: 3.3.1
+            ignore: 7.0.5
+            imurmurhash: 0.1.4
+            is-plain-object: 5.0.0
+            known-css-properties: 0.37.0
+            mathml-tag-names: 2.1.3
+            meow: 13.2.0
+            micromatch: 4.0.8
+            normalize-path: 3.0.0
+            picocolors: 1.1.1
+            postcss: 8.5.8
+            postcss-resolve-nested-selector: 0.1.6
+            postcss-safe-parser: 7.0.1(postcss@8.5.8)
+            postcss-selector-parser: 7.1.1
+            postcss-value-parser: 4.2.0
+            resolve-from: 5.0.0
+            string-width: 4.2.3
+            supports-hyperlinks: 3.2.0
+            svg-tags: 1.0.0
+            table: 6.9.0
+            write-file-atomic: 5.0.1
+        transitivePeerDependencies:
+            - supports-color
+            - typescript
+
+    supports-color@7.2.0:
+        dependencies:
+            has-flag: 4.0.0
+
+    supports-color@8.1.1:
+        dependencies:
+            has-flag: 4.0.0
+
+    supports-hyperlinks@3.2.0:
+        dependencies:
+            has-flag: 4.0.0
+            supports-color: 7.2.0
+
+    supports-preserve-symlinks-flag@1.0.0: {}
+
+    svg-tags@1.0.0: {}
+
+    table@6.9.0:
+        dependencies:
+            ajv: 8.18.0
+            lodash.truncate: 4.4.2
+            slice-ansi: 4.0.0
+            string-width: 4.2.3
+            strip-ansi: 6.0.1
+
+    test-exclude@6.0.0:
+        dependencies:
+            '@istanbuljs/schema': 0.1.3
+            glob: 7.2.3
+            minimatch: 3.1.5
+
+    tmpl@1.0.5: {}
+
+    to-regex-range@5.0.1:
+        dependencies:
+            is-number: 7.0.0
+
+    type-check@0.4.0:
+        dependencies:
+            prelude-ls: 1.2.1
+
+    type-detect@4.0.8: {}
+
+    type-fest@0.21.3: {}
+
+    undici-types@7.18.2: {}
+
+    update-browserslist-db@1.2.3(browserslist@4.28.1):
+        dependencies:
+            browserslist: 4.28.1
+            escalade: 3.2.0
+            picocolors: 1.1.1
+
+    uri-js@4.4.1:
+        dependencies:
+            punycode: 2.3.1
+
+    util-deprecate@1.0.2: {}
+
+    v8-to-istanbul@9.3.0:
+        dependencies:
+            '@jridgewell/trace-mapping': 0.3.31
+            '@types/istanbul-lib-coverage': 2.0.6
+            convert-source-map: 2.0.0
+
+    walker@1.0.8:
+        dependencies:
+            makeerror: 1.0.12
+
+    which@1.3.1:
+        dependencies:
+            isexe: 2.0.0
+
+    which@2.0.2:
+        dependencies:
+            isexe: 2.0.0
+
+    word-wrap@1.2.5: {}
+
+    wrap-ansi@7.0.0:
+        dependencies:
+            ansi-styles: 4.3.0
+            string-width: 4.2.3
+            strip-ansi: 6.0.1
+
+    wrappy@1.0.2: {}
+
+    write-file-atomic@4.0.2:
+        dependencies:
+            imurmurhash: 0.1.4
+            signal-exit: 3.0.7
+
+    write-file-atomic@5.0.1:
+        dependencies:
+            imurmurhash: 0.1.4
+            signal-exit: 4.1.0
+
+    y18n@5.0.8: {}
+
+    yallist@3.1.1: {}
+
+    yargs-parser@21.1.1: {}
+
+    yargs@17.7.2:
+        dependencies:
+            cliui: 8.0.1
+            escalade: 3.2.0
+            get-caller-file: 2.0.5
+            require-directory: 2.1.1
+            string-width: 4.2.3
+            y18n: 5.0.8
+            yargs-parser: 21.1.1
+
+    yocto-queue@0.1.0: {}


### PR DESCRIPTION
**💡 What: The UX enhancement added**
Moved the `opacity: 0.8` from the static `#nav .portfolio-link` parent table cell directly to the interactive anchor element (`a`), adding a smooth transition. I also added `:hover` and `:focus` states set to `opacity: 1` to restore full contrast on interaction.

**🎯 Why: The user problem it solves**
Previously, because the opacity was set on the parent container without any overrides, the interactive links inside the navigation menu always remained artificially dimmed. Adding visual feedback when hovered or tab-focused makes the interface feel much more responsive and intuitive.

**♿ Accessibility: Any a11y improvements made**
By explicitly including the `:focus` state (`#nav .portfolio-link a:hover, #nav .portfolio-link a:focus { opacity: 1; }`), keyboard users navigating with 'Tab' now receive the exact same clear, visual feedback as mouse users, improving navigation clarity and WCAG contrast during interaction.

---
*PR created automatically by Jules for task [5566701820706077027](https://jules.google.com/task/5566701820706077027) started by @ryusoh*