### PR TITLE
test: Add missing coverage for preloader and ambient loader scripts

### DIFF
--- a/tests/js/ambient/loader.test.js
+++ b/tests/js/ambient/loader.test.js
@@ -110,4 +110,27 @@ describe('ambient/loader.js', () => {
         );
         expect(loadedQuantum).toBe(false);
     });
+
+    test('ignores synchronous errors during initialization gracefully', () => {
+        Object.defineProperty(context.window, 'matchMedia', {
+            get: () => {
+                throw new Error('Simulated synchronous error');
+            },
+        });
+
+        expect(() => {
+            vm.createContext(context);
+            vm.runInContext(code, context);
+        }).not.toThrow();
+    });
+
+    test('ignores promise rejections from CDNLoader gracefully', async () => {
+        mockCDNLoader.loadCssWithFallback.mockRejectedValue(new Error('Simulated network error'));
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        await new Promise(process.nextTick);
+        await new Promise(process.nextTick);
+    });
 });

--- a/tests/js/preloader.test.js
+++ b/tests/js/preloader.test.js
@@ -213,4 +213,38 @@ describe('AssetPreloader', () => {
         preloader.init();
         expect(mockWindow.addEventListener).not.toHaveBeenCalled();
     });
+
+    test('initializes preloader on DOMContentLoaded', () => {
+        const sourcePath = path.resolve(__dirname, '../../js/preloader.js');
+        const originalCode = fs.readFileSync(sourcePath, 'utf8');
+
+        context.document.addEventListener = jest.fn((event, cb) => {
+            if (event === 'DOMContentLoaded') {
+                context.__domContentLoadedCb = cb;
+            }
+        });
+
+        vm.createContext(context);
+
+        // Create a fresh context to avoid 'Identifier has already been declared'
+        const freshContext = {
+            document: context.document,
+            window: context.window,
+            navigator: context.navigator,
+            console: console,
+            module: { exports: {} },
+        };
+        freshContext.document.addEventListener = context.document.addEventListener;
+        vm.createContext(freshContext);
+        vm.runInContext(originalCode, freshContext);
+
+        expect(context.document.addEventListener).toHaveBeenCalledWith(
+            'DOMContentLoaded',
+            expect.any(Function)
+        );
+
+        expect(() => {
+            context.__domContentLoadedCb();
+        }).not.toThrow();
+    });
 });


### PR DESCRIPTION
This pull request adds 3 missing test cases for Javascript files to increase overall test coverage:
1. `preloader.js`: Test cases added to cover the `DOMContentLoaded` logic block initializing the preloader on page load.
2. `ambient/loader.js`: Test cases added to cover the `try-catch` block trapping simulated synchronous exceptions.
3. `ambient/loader.js`: Test cases added to cover rejected Promise catching resulting from `CDNLoader` methods.

All Javascript linting checks and the Jest unit test suite are fully green.

---
*PR created automatically by Jules for task [4044257794512072756](https://jules.google.com/task/4044257794512072756) started by @ryusoh*