### PR TITLE
Bolt: Eliminate redundant NodeList iteration in FontAwesome loader

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,5 +33,6 @@
 **Action:** Always avoid reading DOM layout properties (`clientWidth`, `offsetWidth`, `getBoundingClientRect`, etc.) inside tight loops like `requestAnimationFrame`. Instead, cache these values during `resize` events and reuse the cached dimensions for calculations.
 
 ## 2026-03-18 - Redundant NodeList to Array conversion and Iteration
+
 **Learning:** Iterating over a DOM `NodeList` multiple times, especially by first doing a boolean check and then converting it to an `Array` using `Array.from()` to use methods like `.find()`, causes unnecessary memory allocations and blocks the main thread during critical page load phases.
 **Action:** Use a single `for...of` loop to iterate over DOM `NodeList` elements and store the reference to the target element directly instead of running multiple iteration passes and creating intermediate `Array` objects.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 
 **Learning:** Found that `metrics()` in `js/ambient/ambient.js` was being called inside the 60fps `requestAnimationFrame` loop (`s.update` and `reset()`). This function read `clientWidth` and `clientHeight` from the DOM. Reading layout properties triggers synchronous layout calculations if the DOM is invalidated, which can severely degrade animation performance and cause layout thrashing on the main thread.
 **Action:** Always avoid reading DOM layout properties (`clientWidth`, `offsetWidth`, `getBoundingClientRect`, etc.) inside tight loops like `requestAnimationFrame`. Instead, cache these values during `resize` events and reuse the cached dimensions for calculations.
+
+## 2026-03-18 - Redundant NodeList to Array conversion and Iteration
+**Learning:** Iterating over a DOM `NodeList` multiple times, especially by first doing a boolean check and then converting it to an `Array` using `Array.from()` to use methods like `.find()`, causes unnecessary memory allocations and blocks the main thread during critical page load phases.
+**Action:** Use a single `for...of` loop to iterate over DOM `NodeList` elements and store the reference to the target element directly instead of running multiple iteration passes and creating intermediate `Array` objects.

--- a/js/font-awesome-loader.js
+++ b/js/font-awesome-loader.js
@@ -149,36 +149,33 @@ class FontAwesomeLoader {
     waitForFontLoad() {
         // Check for the CSS to be loaded
         const checkCSSLoaded = () => {
+            /**
+             * Bolt Optimization:
+             * - What: Replace separate existence check loop and Array.from().find() with a single loop.
+             * - Why: The previous implementation iterated over the DOM NodeList to find a boolean flag, then converted the same NodeList into an Array (causing memory allocation/GC overhead), and iterated it AGAIN using `.find()` to grab the element.
+             * - Impact: Eliminates redundant O(N) main-thread execution time and an unnecessary Array object allocation during the critical page load phase.
+             */
             const links = document.querySelectorAll('link[rel="stylesheet"]');
-            let fontAwesomeFound = false;
+            let faLink = null;
 
             for (const link of links) {
                 if (
                     link.href &&
                     (link.href.includes('font-awesome') || link.href.includes('fontawesome'))
                 ) {
-                    fontAwesomeFound = true;
+                    faLink = link;
                     break;
                 }
             }
 
-            if (fontAwesomeFound) {
-                // If we found the FA link, check its loading status
-                const faLink = Array.from(links).find(
-                    (link) =>
-                        link.href &&
-                        (link.href.includes('font-awesome') || link.href.includes('fontawesome'))
-                );
-
-                if (faLink) {
-                    faLink.onload = () => {
-                        if (!this.fontAwesomeLoaded) {
-                            this.fontAwesomeLoaded = true;
-                            this.showIcons();
-                            this.stopChecking();
-                        }
-                    };
-                }
+            if (faLink) {
+                faLink.onload = () => {
+                    if (!this.fontAwesomeLoaded) {
+                        this.fontAwesomeLoaded = true;
+                        this.showIcons();
+                        this.stopChecking();
+                    }
+                };
             }
         };
 


### PR DESCRIPTION
## What
Replaced a separate boolean flag check loop and an `Array.from(links).find(...)` conversion with a single `for...of` loop in `waitForFontLoad` within `js/font-awesome-loader.js`.

## Why
The previous implementation iterated over the DOM `NodeList` to find a boolean flag, then converted the same `NodeList` into an `Array` (causing memory allocation and potential garbage collection overhead), and iterated it again using `.find()` to grab the element.

## Impact
Eliminates a redundant O(N) DOM `NodeList` iteration and an unnecessary intermediate `Array` object allocation on the main thread during the critical page load phase, improving execution performance.

## Measurement
Verify the changes by running `pnpm lint` and `pnpm test`, which validates that the functional behavior of the `waitForFontLoad` icon fallback logic has not changed despite the loop consolidation.

---
*PR created automatically by Jules for task [2507382436958095894](https://jules.google.com/task/2507382436958095894) started by @ryusoh*