### PR TITLE
Palette: Add Semantic Landmarks for Screen Reader Navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,8 @@
 
 **Learning:** Users often expect standard "Escape" keys to exit immersive, gallery-style views, similar to closing a modal or lightbox. Providing explicit keyboard navigation out of these isolated views reduces friction significantly for keyboard users.
 **Action:** When creating standalone visual projects or deeply nested immersive layouts, ensure `Escape` is bound to navigating "Back" to the main context and exposed via `aria-keyshortcuts`.
+
+## 2026-11-20 - [Accessibility: HTML5 Semantic Landmarks]
+
+**Learning:** Replacing non-semantic wrapper `<div>` and `<section>` elements with HTML5 `<main>` tags, and wrapping layout-based navigation structures with `<nav aria-label="...">` tags drastically improves the ability of screen reader users to navigate web pages using standard keyboard shortcuts (e.g., landmark navigation).
+**Action:** When inspecting a document's HTML structure, ensure that primary content and primary navigation regions are wrapped in semantic landmarks like `<main>` and `<nav>`. Additionally, remember to add these new elements to CSS resets (e.g., `main, nav { display: block; }`) to maintain visual layout consistency.

--- a/css/main_style.css
+++ b/css/main_style.css
@@ -95,6 +95,7 @@ figure,
 footer,
 header,
 hgroup,
+main,
 menu,
 nav,
 section {

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     <body data-page-type="home">
         <div id="mimida"></div>
         <div id="cont">
-            <div id="main">
+            <main id="main">
                 <h1><span>Zhuang Liu</span></h1>
                 <p id="headline">
                     Street Photographer
@@ -97,34 +97,36 @@
                         </a>
                     </span>
                 </p>
-                <table id="nav" role="presentation">
-                    <tbody>
-                        <tr>
-                            <td class="portfolio-category" rowspan="3">Portfolio</td>
-                            <td class="portfolio-link">
-                                <a href="./p1/" data-page-transition data-destination="project"
-                                    >I Tear Up the Bay When I Come Through</a
-                                >
-                            </td>
-                        </tr>
-                        <tr>
-                            <!-- The "Portfolio" cell is spanned from the row above -->
-                            <td class="portfolio-link">
-                                <a href="./p2/" data-page-transition data-destination="project"
-                                    >I Do Not Care If We Go Down in History as Barbarians</a
-                                >
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="portfolio-link">
-                                <a href="./p3/" data-page-transition data-destination="project"
-                                    >Aerobatic Activities</a
-                                >
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                <nav aria-label="Portfolio projects">
+                    <table id="nav" role="presentation">
+                        <tbody>
+                            <tr>
+                                <td class="portfolio-category" rowspan="3">Portfolio</td>
+                                <td class="portfolio-link">
+                                    <a href="./p1/" data-page-transition data-destination="project"
+                                        >I Tear Up the Bay When I Come Through</a
+                                    >
+                                </td>
+                            </tr>
+                            <tr>
+                                <!-- The "Portfolio" cell is spanned from the row above -->
+                                <td class="portfolio-link">
+                                    <a href="./p2/" data-page-transition data-destination="project"
+                                        >I Do Not Care If We Go Down in History as Barbarians</a
+                                    >
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="portfolio-link">
+                                    <a href="./p3/" data-page-transition data-destination="project"
+                                        >Aerobatic Activities</a
+                                    >
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </nav>
+            </main>
         </div>
         <div id="works-wrap"></div>
         <footer>

--- a/p1/index.html
+++ b/p1/index.html
@@ -119,7 +119,7 @@
 
     <body data-page-type="project">
         <!-- Content -->
-        <section class="article-container">
+        <main class="article-container">
             <!-- Back Home -->
 
             <!-- prettier-ignore -->
@@ -263,7 +263,7 @@
                     </div>
                 </div>
             </article>
-        </section>
+        </main>
 
         <!-- TOC -->
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -119,7 +119,7 @@
 
     <body data-page-type="project">
         <!-- Content -->
-        <section class="article-container">
+        <main class="article-container">
             <!-- Back Home -->
 
             <!-- prettier-ignore -->
@@ -269,7 +269,7 @@
                     </div>
                 </div>
             </article>
-        </section>
+        </main>
 
         <!-- TOC -->
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -113,7 +113,7 @@
 
     <body data-page-type="project">
         <!-- Content -->
-        <section class="article-container">
+        <main class="article-container">
             <!-- Back Home -->
 
             <!-- prettier-ignore -->
@@ -252,7 +252,7 @@
                     </div>
                 </div>
             </article>
-        </section>
+        </main>
 
         <!-- TOC -->
 


### PR DESCRIPTION
💡 What: Replaced non-semantic `<div>` and `<section>` elements with HTML5 `<main>` elements, and wrapped layout navigation with `<nav aria-label="...">`.
🎯 Why: Without these landmarks, screen reader users cannot quickly jump to the core content of the application or the primary navigation. Adding these elements significantly reduces friction for non-visual navigation.
📸 Before/After: Visual changes are nil.
♿ Accessibility: Ensures semantic correctness for screen readers, allowing shortcut navigation via landmark menus.

Changes include:
* `index.html`: Added `<main id="main">` and `<nav aria-label="Portfolio projects">`.
* `p1/index.html`, `p2/index.html`, `p3/index.html`: Replaced `<section class="article-container">` with `<main class="article-container">`.
* `css/main_style.css`: Added `main` to the default `display: block` elements.

---
*PR created automatically by Jules for task [16242603069159589732](https://jules.google.com/task/16242603069159589732) started by @ryusoh*