### PR TITLE
Sentinel: [MEDIUM] Enforce HTTPS to prevent MITM downgrade on external assets

### DIFF
--- a/js/ga.js
+++ b/js/ga.js
@@ -12,7 +12,7 @@
     a.async = 1;
     a.src = g;
     m.parentNode.insertBefore(a, m);
-})(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+})(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
 // Existing property and initial pageview
 try {

--- a/p1/index.html
+++ b/p1/index.html
@@ -81,12 +81,12 @@
             type="text/css"
         />
         <link
-            href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
+            href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
             rel="stylesheet"
             type="text/css"
         />
         <link
-            href="//fonts.googleapis.com/css?family=Noto+Serif:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
+            href="https://fonts.googleapis.com/css?family=Noto+Serif:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
             rel="stylesheet"
             type="text/css"
         />

--- a/p2/index.html
+++ b/p2/index.html
@@ -81,12 +81,12 @@
             type="text/css"
         />
         <link
-            href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
+            href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
             rel="stylesheet"
             type="text/css"
         />
         <link
-            href="//fonts.googleapis.com/css?family=Noto+Serif:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
+            href="https://fonts.googleapis.com/css?family=Noto+Serif:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
             rel="stylesheet"
             type="text/css"
         />

--- a/p3/index.html
+++ b/p3/index.html
@@ -75,12 +75,12 @@
             type="text/css"
         />
         <link
-            href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
+            href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
             rel="stylesheet"
             type="text/css"
         />
         <link
-            href="//fonts.googleapis.com/css?family=Noto+Serif:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
+            href="https://fonts.googleapis.com/css?family=Noto+Serif:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"
             rel="stylesheet"
             type="text/css"
         />

--- a/tests/js/ga.test.js
+++ b/tests/js/ga.test.js
@@ -45,7 +45,7 @@ describe('ga.js bootstrap', () => {
         expect(context.document.createElement).toHaveBeenCalledWith('script');
         expect(context.document.getElementsByTagName).toHaveBeenCalledWith('script');
         expect(mockScriptElement.async).toBe(1);
-        expect(mockScriptElement.src).toBe('//www.google-analytics.com/analytics.js');
+        expect(mockScriptElement.src).toBe('https://www.google-analytics.com/analytics.js');
         expect(mockParentNode.insertBefore).toHaveBeenCalledWith(
             mockScriptElement,
             context.document.getElementsByTagName()[0]


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** Protocol-relative URLs (`//www.example.com`) inherit the protocol of the enclosing page. If a user somehow loads the page over plain HTTP, these assets (like Google Analytics or Fonts) would also be requested over insecure HTTP, opening them up to Man-In-The-Middle (MITM) modification or surveillance.
**Impact:** While the site forces HTTPS natively via Cloudflare/GitHub Pages in production, legacy protocol-relative URLs are an anti-pattern. Explicit `https://` ensures external assets are never accidentally downgraded.
**Fix:** Refactored `js/ga.js` and all HTML files (`p1`, `p2`, `p3`) to strictly declare `https://`.
**Verification:** Ran the full Jest test suite. Tests are fully passing after migrating assertions.

---
*PR created automatically by Jules for task [13397666236091822696](https://jules.google.com/task/13397666236091822696) started by @ryusoh*