### PR TITLE
test: expand coverage for loader catch blocks and initialization exceptions

### DIFF
--- a/tests/js/ambient/config/default.test.js
+++ b/tests/js/ambient/config/default.test.js
@@ -57,4 +57,27 @@ describe('ambient/config/default.js', () => {
             vm.runInContext(code, context);
         }).not.toThrow();
     });
+
+    test('logs a warning when initialization fails', () => {
+        context.window = {
+            console: {
+                warn: jest.fn(),
+            },
+        };
+
+        // Use a Proxy or defineProperty to throw when AMBIENT_CONFIG is accessed/set
+        Object.defineProperty(context.window, 'AMBIENT_CONFIG', {
+            get: () => {
+                throw new Error('Simulated config error');
+            },
+        });
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(context.window.console.warn).toHaveBeenCalledWith(
+            'Ambient config initialization failed:',
+            expect.any(Error)
+        );
+    });
 });

--- a/tests/js/ambient/loader.test.js
+++ b/tests/js/ambient/loader.test.js
@@ -31,6 +31,9 @@ describe('ambient/loader.js', () => {
                 innerWidth: 1200,
                 matchMedia: jest.fn().mockReturnValue({ matches: false }),
                 Promise: Promise,
+                console: {
+                    warn: jest.fn(),
+                },
             },
             document: mockDocument,
         };
@@ -132,5 +135,26 @@ describe('ambient/loader.js', () => {
 
         await new Promise(process.nextTick);
         await new Promise(process.nextTick);
+
+        expect(context.window.console.warn).toHaveBeenCalledWith(
+            'Ambient async loader failed:',
+            expect.any(Error)
+        );
+    });
+
+    test('ignores synchronous errors during initialization gracefully and logs warning', () => {
+        Object.defineProperty(context.window, 'matchMedia', {
+            get: () => {
+                throw new Error('Simulated synchronous error');
+            },
+        });
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(context.window.console.warn).toHaveBeenCalledWith(
+            'Ambient initialization failed:',
+            expect.any(Error)
+        );
     });
 });

--- a/tests/js/cursor-init.test.js
+++ b/tests/js/cursor-init.test.js
@@ -16,7 +16,11 @@ describe('js/cursor-init.js', () => {
         mockInitCursor = jest.fn().mockReturnValue({ cursor: { id: 'mocked-cursor' } });
 
         context = {
-            window: {},
+            window: {
+                console: {
+                    warn: jest.fn(),
+                },
+            },
             document: {
                 addEventListener: jest.fn((event, cb) => {
                     if (event === 'DOMContentLoaded') {
@@ -26,7 +30,9 @@ describe('js/cursor-init.js', () => {
                 }),
             },
             initCursor: mockInitCursor,
-            console: console,
+            console: {
+                warn: jest.fn(),
+            },
         };
     });
 
@@ -83,5 +89,35 @@ describe('js/cursor-init.js', () => {
         expect(() => {
             vm.runInContext(customCode, context);
         }).not.toThrow();
+    });
+
+    test('does not throw when initCursor throws but allows bubbling', () => {
+        context.window.gsap = {}; // Mock GSAP
+
+        // Let's modify the custom context to throw
+        const customContext = {
+            ...context,
+            initCursor: jest.fn().mockImplementation(() => {
+                throw new Error('initCursor error');
+            }),
+            document: {
+                addEventListener: jest.fn((event, cb) => {
+                    if (event === 'DOMContentLoaded') {
+                        customContext.__domContentLoadedCb = cb;
+                    }
+                }),
+            },
+        };
+
+        vm.createContext(customContext);
+        vm.runInContext(code, customContext);
+
+        // Trigger DOMContentLoaded which calls initCursor
+        // The script doesn't wrap it in a try-catch, so we assert it throws.
+        expect(() => {
+            customContext.__domContentLoadedCb();
+        }).toThrow('initCursor error');
+
+        expect(customContext.window.cursorInstances).toBeUndefined();
     });
 });


### PR DESCRIPTION
This pull request expands the codebase test coverage by targeting 3 missing edge cases around script evaluation, initialization, and promise unhandled rejections during the page lifecycle:

1. **`js/cursor-init.js`**: Verified that internal crashes within `initCursor` correctly bubble out rather than being silently ignored or causing unmanaged state. 
2. **`js/ambient/loader.js`**: Verified the outer `catch` block correctly triggers and fires `console.warn` upon synchronous errors, and the asynchronous Promise `.catch` block correctly logs failures from `CDNLoader`. 
3. **`js/ambient/config/default.js`**: Verified the `catch` block correctly triggers and fires `console.warn` upon AMBIENT_CONFIG initialization failures.

---
*PR created automatically by Jules for task [13171158299582761255](https://jules.google.com/task/13171158299582761255) started by @ryusoh*