### PR TITLE
🎨 Palette: Add skip-to-content links

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -467,6 +467,27 @@ footer {
     --page-transition-secondary: rgba(206, 35, 35, 0.3);
 }
 
+/* Accessibility: Screen reader only utility class for skip links */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+}
+
 /* Global focus-visible for accessibility */
 :focus-visible {
     outline: 2px solid rgba(206, 35, 35, 0.8) !important;

--- a/css/style.css
+++ b/css/style.css
@@ -1093,6 +1093,27 @@ td {
     }
 }
 
+/* Accessibility: Screen reader only utility class for skip links */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+}
+
 /* Global focus-visible for accessibility */
 :focus-visible {
     outline: 2px solid rgba(206, 35, 35, 0.8) !important;

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
     </head>
 
     <body data-page-type="home">
+        <a href="#main" class="sr-only sr-only-focusable">Skip to content</a>
         <div id="mimida"></div>
         <div id="cont">
             <main id="main">

--- a/p1/index.html
+++ b/p1/index.html
@@ -118,8 +118,9 @@
     </head>
 
     <body data-page-type="project">
+        <a href="#main" class="sr-only sr-only-focusable">Skip to content</a>
         <!-- Content -->
-        <main class="article-container">
+        <main id="main" class="article-container">
             <!-- Back Home -->
 
             <!-- prettier-ignore -->

--- a/p2/index.html
+++ b/p2/index.html
@@ -118,8 +118,9 @@
     </head>
 
     <body data-page-type="project">
+        <a href="#main" class="sr-only sr-only-focusable">Skip to content</a>
         <!-- Content -->
-        <main class="article-container">
+        <main id="main" class="article-container">
             <!-- Back Home -->
 
             <!-- prettier-ignore -->

--- a/p3/index.html
+++ b/p3/index.html
@@ -112,8 +112,9 @@
     </head>
 
     <body data-page-type="project">
+        <a href="#main" class="sr-only sr-only-focusable">Skip to content</a>
         <!-- Content -->
-        <main class="article-container">
+        <main id="main" class="article-container">
             <!-- Back Home -->
 
             <!-- prettier-ignore -->


### PR DESCRIPTION
💡 What: Added visually hidden "Skip to content" links at the top of all pages (`index.html`, `p1`, `p2`, `p3`), targeting the `<main id="main">` elements. Added standard `.sr-only` and `.sr-only-focusable` utility classes to the global stylesheets to support this.
🎯 Why: Keyboard users and screen reader users need a quick way to bypass navigation and jump directly to the main content. The main page previously lacked this standard accessibility feature, and the `<main>` tag was missing an `id` on the subpages.
♿ Accessibility: Improves WCAG 2.4.1 (Bypass Blocks) compliance significantly. Sighted keyboard users can Tab to reveal the link, while screen reader users hear it immediately upon page load.

---
*PR created automatically by Jules for task [4750047604768690244](https://jules.google.com/task/4750047604768690244) started by @ryusoh*