### PR TITLE
Bolt: Remove unnecessary Array allocation in page transitions

### DIFF
--- a/js/page-transition.js
+++ b/js/page-transition.js
@@ -791,7 +791,13 @@ import * as THREE from './vendor/three.module.min.js';
             return;
         }
 
-        const links = Array.prototype.slice.call(document.querySelectorAll('a[' + LINK_ATTR + ']'));
+        /**
+         * Bolt Optimization:
+         * - What: Avoid converting NodeList to Array and use for...of loop directly.
+         * - Why: `document.querySelectorAll` returns a NodeList. Iterating over it directly instead of converting it to an Array with `Array.prototype.slice.call()` avoids unnecessary memory allocation and garbage collection overhead during initialization.
+         * - Impact: Eliminates unnecessary Array object allocation and improves initialization performance.
+         */
+        const links = document.querySelectorAll('a[' + LINK_ATTR + ']');
         function shouldSkipNavBack(element) {
             if (!element) {
                 return false;
@@ -840,7 +846,7 @@ import * as THREE from './vendor/three.module.min.js';
             }
             return isEligibleAnchor(anchor);
         }
-        links.forEach(function (anchor) {
+        for (const anchor of links) {
             anchor.addEventListener('click', function (event) {
                 if (!isValidTransitionClick(event, anchor)) {
                     return;
@@ -848,7 +854,7 @@ import * as THREE from './vendor/three.module.min.js';
                 event.preventDefault();
                 transition.navigate(anchor.href);
             });
-        });
+        }
 
         window.addEventListener('pageshow', function (event) {
             if (!transition.enabled) {


### PR DESCRIPTION
💡 What: The optimization replaces an `Array.prototype.slice.call()` cast on a `NodeList` with a direct iteration using a `for...of` loop in `js/page-transition.js`.
🎯 Why: `document.querySelectorAll` returns a `NodeList`. Converting this NodeList into an Array just to use array iteration methods is redundant and allocates unnecessary memory during page initialization, which negatively impacts load performance.
📊 Impact: Eliminates an unnecessary Array object allocation and decreases garbage collection overhead, improving time-to-interactive slightly.
🔬 Measurement: Verified via unit tests (`pnpm test`), linting, and formatting checks that the functional transition behavior is identical. No visual regressions or console errors were observed.

---
*PR created automatically by Jules for task [726959260283516109](https://jules.google.com/task/726959260283516109) started by @ryusoh*