### PR TITLE
test: add 3 missing tests to improve coverage

### DIFF
--- a/tests/js/ga.test.js
+++ b/tests/js/ga.test.js
@@ -100,7 +100,10 @@ describe('ga.js bootstrap', () => {
             vm.runInContext(customCode, context);
         }).not.toThrow();
         // The error created in vm does not have the same prototype as the host environment's Error, so expect.any(Error) fails
-        expect(context.window.console.warn).toHaveBeenCalledWith('Google Analytics initialization failed:', expect.anything());
+        expect(context.window.console.warn).toHaveBeenCalledWith(
+            'Google Analytics initialization failed:',
+            expect.anything()
+        );
     });
 
     test('handles case where window.ga is not a function', () => {

--- a/tests/js/ga.test.js
+++ b/tests/js/ga.test.js
@@ -86,6 +86,11 @@ describe('ga.js bootstrap', () => {
     });
 
     test('gracefully handles throwing inside the try-catch block', () => {
+        context.window = {
+            console: {
+                warn: jest.fn(),
+            },
+        };
         const customCode = code.replace(
             "if (typeof window.ga === 'function') {",
             "if (typeof window.ga === 'function') { throw new Error('GA error');"
@@ -94,6 +99,8 @@ describe('ga.js bootstrap', () => {
             vm.createContext(context);
             vm.runInContext(customCode, context);
         }).not.toThrow();
+        // The error created in vm does not have the same prototype as the host environment's Error, so expect.any(Error) fails
+        expect(context.window.console.warn).toHaveBeenCalledWith('Google Analytics initialization failed:', expect.anything());
     });
 
     test('handles case where window.ga is not a function', () => {

--- a/tests/js/loader/vendorLoader.test.js
+++ b/tests/js/loader/vendorLoader.test.js
@@ -74,4 +74,27 @@ describe('loader/vendorLoader.js', () => {
             vm.runInContext(code, context);
         }).not.toThrow();
     });
+
+    test('logs a warning when initialization fails', () => {
+        context.window = {
+            console: {
+                warn: jest.fn(),
+            },
+        };
+
+        // Simulated config error by throwing when CDNLoader is accessed
+        Object.defineProperty(context.window, 'CDNLoader', {
+            get: () => {
+                throw new Error('Simulated config error');
+            },
+        });
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(context.window.console.warn).toHaveBeenCalledWith(
+            'Vendor Loader failed:',
+            expect.any(Error)
+        );
+    });
 });

--- a/tests/js/sw.test.js
+++ b/tests/js/sw.test.js
@@ -189,6 +189,39 @@ describe('Service Worker', () => {
             expect(mockCache.put).toHaveBeenCalledWith(mockRequest, mockResponseClone);
         });
 
+        test('should skip caching if response has Content-Range header during Cache First fallback', async () => {
+            const fetchHandler = getEventHandler('fetch');
+            const mockRequest = {
+                url: 'https://example.com/images/large.jpg',
+                destination: 'image',
+                headers: { has: jest.fn().mockReturnValue(false) },
+            };
+            const mockEvent = {
+                request: mockRequest,
+                respondWith: jest.fn(),
+            };
+
+            mockCaches.match.mockResolvedValue(undefined);
+
+            const mockResponse = {
+                ok: true,
+                status: 200,
+                type: 'basic',
+                headers: { get: jest.fn().mockReturnValue('bytes 21010-47021/47022') }, // Content-Range header present
+            };
+            mockFetch.mockResolvedValue(mockResponse);
+
+            fetchHandler(mockEvent);
+
+            const respondWithPromise = mockEvent.respondWith.mock.calls[0][0];
+            const result = await respondWithPromise;
+
+            expect(mockFetch).toHaveBeenCalledWith(mockRequest);
+            expect(result).toBe(mockResponse);
+
+            expect(mockCache.put).not.toHaveBeenCalled();
+        });
+
         test('should skip caching if response is invalid (e.g. status 500) during Cache First fallback', async () => {
             const fetchHandler = getEventHandler('fetch');
             const mockRequest = {


### PR DESCRIPTION
Adds exactly three missing test coverage blocks targeting:
- `ga.js`: Handle throwing inside the try-catch block for Google Analytics initialization
- `sw.js`: Missing caching bypass for HTTP `Content-Range` responses.
- `vendorLoader.js`: Handles and logs configuration initialization errors.

This satisfies the max-automation requirement to discover exactly 3 missing coverage tests per run without interaction.

---
*PR created automatically by Jules for task [12881149586551053254](https://jules.google.com/task/12881149586551053254) started by @ryusoh*