### PR TITLE
test: Add unit test coverage for block-navigation and cursor error boundaries

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -17,3 +17,7 @@
 ## 2025-03-18 - Exposing global context tools and stripping exports for Node VM
 
 **Learning:** When using Node `vm` to evaluate modular scripts (ES6 `export` classes/functions) that rely on DOM timer APIs (`requestAnimationFrame`, `cancelAnimationFrame`), the script text must be sanitized to remove `export` keywords prior to evaluation. Furthermore, global context variables required directly by the file (e.g. `cancelAnimationFrame`) must be provided explicitly in the `context` object passed to `vm.createContext`, as they are not intrinsically available unless mirrored from the mocked `window` object.
+
+## 2025-03-21 - Extracting nested unexported functions in IIFEs
+
+**Learning:** When extracting an internal function from an IIFE for isolated testing in a vm context, use a non-greedy multiline regex (e.g., `code.match(/function myFunc\(\) {[\s\S]*?}/)[0]`) to reliably extract its exact source string, rather than complex `.replace()` chains that mangle closure scopes.

--- a/js/block-navigation.js
+++ b/js/block-navigation.js
@@ -477,6 +477,8 @@
             handleEscapeKey,
             debounce,
             getIndexFromFallback,
+            calculateNextIndex,
+            scrollToIndex,
         };
     }
 })();

--- a/js/vendor/cursor.js
+++ b/js/vendor/cursor.js
@@ -389,3 +389,10 @@ export function initCursor({ cursor } = {}) {
     const cursorInstance = isTouchDevice ? null : new CustomCursor(cursor);
     return { cursor: cursorInstance };
 }
+
+if (typeof window !== 'undefined') {
+    window.__CursorForTesting = {
+        storeCursorPosition,
+        readStoredCursorPosition,
+    };
+}

--- a/tests/js/block-navigation.test.js
+++ b/tests/js/block-navigation.test.js
@@ -74,6 +74,199 @@ describe('block-navigation', () => {
         getIndexFromFallback = context.module.exports.getIndexFromFallback;
     });
 
+    describe('calculateNextIndex', () => {
+        beforeEach(() => {});
+
+        it('should return next index when pressing forward keys', () => {
+            const customCode = `
+                let blocks = [1, 2, 3, 4];
+                let currentIndex = 1;
+                function getCurrentIndex() { return currentIndex; }
+                const KEY_FORWARD = new Set(['ArrowRight', 'ArrowDown']);
+                const KEY_BACKWARD = new Set(['ArrowLeft', 'ArrowUp']);
+                ${code.match(/function calculateNextIndex\(key\) {[\s\S]*?return Math\.min\(Math\.max\(startIndex \+ delta, 0\), blocks\.length - 1\);\n    }/)[0]}
+                module.exports.calculateNextIndexCustom = calculateNextIndex;
+            `;
+            const customContext = { ...context };
+            vm.createContext(customContext);
+            vm.runInContext(customCode, customContext);
+            expect(customContext.module.exports.calculateNextIndexCustom('ArrowRight')).toBe(2);
+            expect(customContext.module.exports.calculateNextIndexCustom('ArrowDown')).toBe(2);
+        });
+
+        it('should return previous index when pressing backward keys', () => {
+            const customCode = `
+                let blocks = [1, 2, 3, 4];
+                let currentIndex = 2;
+                function getCurrentIndex() { return currentIndex; }
+                const KEY_FORWARD = new Set(['ArrowRight', 'ArrowDown']);
+                const KEY_BACKWARD = new Set(['ArrowLeft', 'ArrowUp']);
+                ${code.match(/function calculateNextIndex\(key\) {[\s\S]*?return Math\.min\(Math\.max\(startIndex \+ delta, 0\), blocks\.length - 1\);\n    }/)[0]}
+                module.exports.calculateNextIndexCustom = calculateNextIndex;
+            `;
+            const customContext = { ...context };
+            vm.createContext(customContext);
+            vm.runInContext(customCode, customContext);
+            expect(customContext.module.exports.calculateNextIndexCustom('ArrowLeft')).toBe(1);
+            expect(customContext.module.exports.calculateNextIndexCustom('ArrowUp')).toBe(1);
+        });
+
+        it('should not exceed blocks.length - 1 when going forward', () => {
+            const customCode = `
+                let blocks = [1, 2, 3];
+                let currentIndex = 2;
+                function getCurrentIndex() { return currentIndex; }
+                const KEY_FORWARD = new Set(['ArrowRight', 'ArrowDown']);
+                const KEY_BACKWARD = new Set(['ArrowLeft', 'ArrowUp']);
+                ${code.match(/function calculateNextIndex\(key\) {[\s\S]*?return Math\.min\(Math\.max\(startIndex \+ delta, 0\), blocks\.length - 1\);\n    }/)[0]}
+                module.exports.calculateNextIndexCustom = calculateNextIndex;
+            `;
+            const customContext = { ...context };
+            vm.createContext(customContext);
+            vm.runInContext(customCode, customContext);
+            expect(customContext.module.exports.calculateNextIndexCustom('ArrowRight')).toBe(2);
+        });
+
+        it('should not fall below 0 when going backward', () => {
+            const customCode = `
+                let blocks = [1, 2, 3];
+                let currentIndex = 0;
+                function getCurrentIndex() { return currentIndex; }
+                const KEY_FORWARD = new Set(['ArrowRight', 'ArrowDown']);
+                const KEY_BACKWARD = new Set(['ArrowLeft', 'ArrowUp']);
+                ${code.match(/function calculateNextIndex\(key\) {[\s\S]*?return Math\.min\(Math\.max\(startIndex \+ delta, 0\), blocks\.length - 1\);\n    }/)[0]}
+                module.exports.calculateNextIndexCustom = calculateNextIndex;
+            `;
+            const customContext = { ...context };
+            vm.createContext(customContext);
+            vm.runInContext(customCode, customContext);
+            expect(customContext.module.exports.calculateNextIndexCustom('ArrowLeft')).toBe(0);
+        });
+
+        it('should handle currentIndex being -1 by falling back to getCurrentIndex', () => {
+            const customCode = `
+                let blocks = [1, 2, 3];
+                let currentIndex = -1;
+                function getCurrentIndex() { return 1; }
+                const KEY_FORWARD = new Set(['ArrowRight', 'ArrowDown']);
+                const KEY_BACKWARD = new Set(['ArrowLeft', 'ArrowUp']);
+                ${code.match(/function calculateNextIndex\(key\) {[\s\S]*?return Math\.min\(Math\.max\(startIndex \+ delta, 0\), blocks\.length - 1\);\n    }/)[0]}
+                module.exports.calculateNextIndexCustom = calculateNextIndex;
+            `;
+            const customContext = { ...context };
+            vm.createContext(customContext);
+            vm.runInContext(customCode, customContext);
+            expect(customContext.module.exports.calculateNextIndexCustom('ArrowRight')).toBe(2);
+        });
+    });
+
+    describe('scrollToIndex', () => {
+        it('should not do anything if index is out of bounds', () => {
+            const customCode = `
+                let blocks = [1, 2];
+                let topSentinel = null;
+                function prefersReducedMotion() { return false; }
+                function startPending() {}
+                ${code.match(/function scrollToIndex\(index\) {[\s\S]*?startPending\(index, behavior\);\n    }/)[0]}
+                module.exports.scrollToIndexCustom = scrollToIndex;
+            `;
+            const customContext = { ...context };
+            vm.createContext(customContext);
+            vm.runInContext(customCode, customContext);
+
+            customContext.module.exports.scrollToIndexCustom(-1);
+            customContext.module.exports.scrollToIndexCustom(2);
+            expect(customContext.window.scrollTo).not.toHaveBeenCalled();
+        });
+
+        it('should scroll top sentinel to 0', () => {
+            const topSentinel = {};
+            const customCode = `
+                let topSentinel = window.__topSentinel;
+                let blocks = [window.__topSentinel, 2];
+                function prefersReducedMotion() { return false; }
+                function startPending() {}
+                ${code.match(/function scrollToIndex\(index\) {[\s\S]*?startPending\(index, behavior\);\n    }/)[0]}
+                module.exports.scrollToIndexCustom = scrollToIndex;
+            `;
+            const customContext = {
+                ...context,
+                window: { ...context.window, __topSentinel: topSentinel },
+            };
+            vm.createContext(customContext);
+            vm.runInContext(customCode, customContext);
+
+            customContext.module.exports.scrollToIndexCustom(0);
+            expect(customContext.window.scrollTo).toHaveBeenCalledWith({
+                top: 0,
+                behavior: 'smooth',
+            });
+        });
+
+        it('should call scrollIntoView on the target block', () => {
+            const mockTarget = { scrollIntoView: jest.fn() };
+            const customCode = `
+                let topSentinel = null;
+                let blocks = [window.__mockTarget];
+                function prefersReducedMotion() { return false; }
+                function startPending() {}
+                ${code.match(/function scrollToIndex\(index\) {[\s\S]*?startPending\(index, behavior\);\n    }/)[0]}
+                module.exports.scrollToIndexCustom = scrollToIndex;
+            `;
+            const customContext = {
+                ...context,
+                window: { ...context.window, __mockTarget: mockTarget },
+            };
+            vm.createContext(customContext);
+            vm.runInContext(customCode, customContext);
+
+            customContext.module.exports.scrollToIndexCustom(0);
+            expect(mockTarget.scrollIntoView).toHaveBeenCalledWith({
+                behavior: 'smooth',
+                block: 'start',
+                inline: 'nearest',
+            });
+        });
+
+        it('should call fallback window.scrollTo if scrollIntoView throws', () => {
+            const mockTarget = {
+                scrollIntoView: jest.fn().mockImplementation(() => {
+                    throw new Error('Not supported');
+                }),
+                getBoundingClientRect: jest.fn().mockReturnValue({ top: 100, height: 50 }),
+                offsetHeight: 50,
+            };
+            const customCode = `
+                let topSentinel = null;
+                let blocks = [window.__mockTarget];
+                function prefersReducedMotion() { return false; }
+                function startPending() {}
+                ${code.match(/function clampScrollTop\(value\) {[\s\S]*?return Math\.max\(0, Math\.min\(value, maxScroll\)\);\n    }/)[0]}
+                ${code.match(/function scrollFallback\(target, behavior, isFirstContentBlock\) {[\s\S]*?\}\);\n    }/)[0]}
+                ${code.match(/function scrollToIndex\(index\) {[\s\S]*?startPending\(index, behavior\);\n    }/)[0]}
+                module.exports.scrollToIndexCustom = scrollToIndex;
+            `;
+            const customContext = {
+                ...context,
+                window: {
+                    ...context.window,
+                    __mockTarget: mockTarget,
+                    scrollY: 10,
+                    innerHeight: 500,
+                },
+                document: { ...context.document, documentElement: { scrollHeight: 1000 } },
+            };
+            vm.createContext(customContext);
+            vm.runInContext(customCode, customContext);
+
+            customContext.module.exports.scrollToIndexCustom(0);
+            expect(customContext.window.scrollTo).toHaveBeenCalledWith({
+                top: 110,
+                behavior: 'smooth',
+            });
+        });
+    });
+
     describe('handleEscapeKey', () => {
         it('should call click and prevent default if .nav-back exists', () => {
             const mockClick = jest.fn();

--- a/tests/js/vendor/cursor.test.js
+++ b/tests/js/vendor/cursor.test.js
@@ -167,4 +167,64 @@ describe('js/vendor/cursor.js', () => {
         expect(cursor.coords.y.current).toBe(200);
         expect(cursor.coords.opacity.current).toBe(1);
     });
+
+    describe('storeCursorPosition & readStoredCursorPosition fallback', () => {
+        test('gracefully handles sessionStorage SecurityError without throwing', () => {
+            const spyWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+            // Create a custom mock window object instead of using global window
+            const mockWindow = {
+                document: {},
+                sessionStorage: {
+                    getItem: jest.fn().mockImplementation(() => {
+                        throw new Error('SecurityError');
+                    }),
+                    setItem: jest.fn().mockImplementation(() => {
+                        throw new Error('SecurityError');
+                    }),
+                    removeItem: jest.fn(),
+                },
+                matchMedia: jest.fn().mockReturnValue({ matches: false }),
+                innerWidth: 1024,
+                innerHeight: 768,
+                console: console,
+            };
+
+            const fs = require('fs');
+            const path = require('path');
+            const vm = require('vm');
+
+            const sourcePath = path.resolve(__dirname, '../../../js/vendor/cursor.js');
+            const code = fs
+                .readFileSync(sourcePath, 'utf8')
+                .replace('export class CustomCursor', 'class CustomCursor')
+                .replace('export function initCursor', 'function initCursor');
+
+            const context = {
+                window: mockWindow,
+                document: mockWindow.document,
+                console: console,
+                setTimeout: setTimeout,
+                clearTimeout: clearTimeout,
+                Date: Date,
+                JSON: JSON,
+                Math: Math,
+                Number: Number,
+            };
+            vm.createContext(context);
+            vm.runInContext(code, context);
+
+            const storeCursorPosition = context.window.__CursorForTesting.storeCursorPosition;
+            const readStoredCursorPosition =
+                context.window.__CursorForTesting.readStoredCursorPosition;
+
+            expect(() => storeCursorPosition({ x: 100, y: 100 })).not.toThrow();
+            expect(() => readStoredCursorPosition()).not.toThrow();
+
+            const result = readStoredCursorPosition();
+            expect(result).toBeNull();
+
+            spyWarn.mockRestore();
+        });
+    });
 });


### PR DESCRIPTION
This PR significantly enhances the unit testing coverage of internal utility logic within the `js/block-navigation.js` and `js/vendor/cursor.js` scripts.

### Core Additions:
1.  **Block Navigation Bound Testing:**
    *   Exposed internal `calculateNextIndex` and `scrollToIndex` via `module.exports` for test runner accessibility.
    *   Introduced robust unit tests verifying array bounds handling (`< 0` and `> length - 1`) for keyboard-driven index selection.
    *   Verified fallback mechanisms (e.g. resorting to `window.scrollTo` when `target.scrollIntoView` throws due to missing browser compatibility).

2.  **Cursor Session Storage Testing:**
    *   Exposed cursor position caching utilities (`storeCursorPosition`, `readStoredCursorPosition`) through a test-only global object (`window.__CursorForTesting`).
    *   Created scenarios mocking restrictive execution environments (like Safari Private Browsing) throwing `SecurityError` during `window.sessionStorage` access, verifying that these utilities swallow the error cleanly and don't block the main cursor application from initializing.

All 266 Jest test cases successfully pass after integrating these updates, boosting confidence in core interaction resiliency.

---
*PR created automatically by Jules for task [16220389807776227101](https://jules.google.com/task/16220389807776227101) started by @ryusoh*