### PR TITLE
test: add test coverage for missing window.console handling scenarios

### DIFF
--- a/tests/js/ambient/config/default.test.js
+++ b/tests/js/ambient/config/default.test.js
@@ -80,4 +80,22 @@ describe('ambient/config/default.js', () => {
             expect.any(Error)
         );
     });
+
+    test('gracefully handles missing window.console.warn without throwing', () => {
+        context.window = {
+            console: {}, // Missing warn
+        };
+
+        // Use a Proxy or defineProperty to throw when AMBIENT_CONFIG is accessed/set
+        Object.defineProperty(context.window, 'AMBIENT_CONFIG', {
+            get: () => {
+                throw new Error('Simulated config error');
+            },
+        });
+
+        expect(() => {
+            vm.createContext(context);
+            vm.runInContext(code, context);
+        }).not.toThrow();
+    });
 });

--- a/tests/js/ga.test.js
+++ b/tests/js/ga.test.js
@@ -114,4 +114,18 @@ describe('ga.js bootstrap', () => {
 
         expect(context.window.ga).toBe('not-a-function');
     });
+
+    test('gracefully handles missing window.console.warn without throwing', () => {
+        context.window = {
+            console: {}, // Missing warn
+        };
+        const customCode = code.replace(
+            "if (typeof window.ga === 'function') {",
+            "if (typeof window.ga === 'function') { throw new Error('GA error');"
+        );
+        expect(() => {
+            vm.createContext(context);
+            vm.runInContext(customCode, context);
+        }).not.toThrow();
+    });
 });

--- a/tests/js/loader/vendorLoader.test.js
+++ b/tests/js/loader/vendorLoader.test.js
@@ -97,4 +97,21 @@ describe('loader/vendorLoader.js', () => {
             expect.any(Error)
         );
     });
+
+    test('gracefully handles missing window.console.warn without throwing', () => {
+        context.window = {
+            console: {}, // Missing warn
+        };
+
+        Object.defineProperty(context.window, 'CDNLoader', {
+            get: () => {
+                throw new Error('Simulated config error');
+            },
+        });
+
+        expect(() => {
+            vm.createContext(context);
+            vm.runInContext(code, context);
+        }).not.toThrow();
+    });
 });


### PR DESCRIPTION
This PR increases test coverage by implementing test cases for 3 specific edge cases identified during manual test suite inspection, as coverage natively reports 0% for `vm.runInContext`. It explicitly tests the `catch` blocks where `window.console.warn` is used as a fallback without throwing an error if the `console` object or `console.warn` itself is undefined.

- Added coverage in `tests/js/ga.test.js`.
- Added coverage in `tests/js/loader/vendorLoader.test.js`.
- Added coverage in `tests/js/ambient/config/default.test.js`.

---
*PR created automatically by Jules for task [12668812749495707409](https://jules.google.com/task/12668812749495707409) started by @ryusoh*