### PR TITLE
🎨 Palette: Fix skip-to-content focus transfer with tabindex

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,8 @@
 
 **Learning:** Replacing non-semantic wrapper `<div>` and `<section>` elements with HTML5 `<main>` tags, and wrapping layout-based navigation structures with `<nav aria-label="...">` tags drastically improves the ability of screen reader users to navigate web pages using standard keyboard shortcuts (e.g., landmark navigation).
 **Action:** When inspecting a document's HTML structure, ensure that primary content and primary navigation regions are wrapped in semantic landmarks like `<main>` and `<nav>`. Additionally, remember to add these new elements to CSS resets (e.g., `main, nav { display: block; }`) to maintain visual layout consistency.
+
+## 2026-11-20 - [Accessibility: Skip-to-content Targets]
+
+**Learning:** "Skip to content" links (with visually hidden `.sr-only` classes) are great for keyboard users, but if the target element (like `<main id="main">`) is not inherently focusable, some browsers will scroll the viewport but fail to move the actual focus. When the user presses Tab again, focus jumps back to the top of the page.
+**Action:** Always add `tabindex="-1"` to the target element of a skip link. This makes the element programmatically focusable without adding it to the normal tab order, ensuring focus is reliably transferred so the next Tab keypress moves into the main content.

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
         <a href="#main" class="sr-only sr-only-focusable">Skip to content</a>
         <div id="mimida"></div>
         <div id="cont">
-            <main id="main">
+            <main id="main" tabindex="-1">
                 <h1><span>Zhuang Liu</span></h1>
                 <p id="headline">
                     Street Photographer

--- a/p1/index.html
+++ b/p1/index.html
@@ -120,7 +120,7 @@
     <body data-page-type="project">
         <a href="#main" class="sr-only sr-only-focusable">Skip to content</a>
         <!-- Content -->
-        <main id="main" class="article-container">
+        <main id="main" class="article-container" tabindex="-1">
             <!-- Back Home -->
 
             <!-- prettier-ignore -->

--- a/p2/index.html
+++ b/p2/index.html
@@ -120,7 +120,7 @@
     <body data-page-type="project">
         <a href="#main" class="sr-only sr-only-focusable">Skip to content</a>
         <!-- Content -->
-        <main id="main" class="article-container">
+        <main id="main" class="article-container" tabindex="-1">
             <!-- Back Home -->
 
             <!-- prettier-ignore -->

--- a/p3/index.html
+++ b/p3/index.html
@@ -114,7 +114,7 @@
     <body data-page-type="project">
         <a href="#main" class="sr-only sr-only-focusable">Skip to content</a>
         <!-- Content -->
-        <main id="main" class="article-container">
+        <main id="main" class="article-container" tabindex="-1">
             <!-- Back Home -->
 
             <!-- prettier-ignore -->


### PR DESCRIPTION
💡 What: Added `tabindex="-1"` to the `<main id="main">` elements across `index.html`, `p1/index.html`, `p2/index.html`, and `p3/index.html`. Also updated the `palette.md` journal with this critical learning.
🎯 Why: Without `tabindex="-1"`, some browsers scroll the viewport down to the target element when the visually hidden "Skip to content" link is activated, but fail to move the programmatic focus. When the user hits the Tab key again, focus resets to the top of the page. Making the `<main>` element programmatically focusable ensures keyboard users don't get trapped at the top of the navigation order.
📸 Before/After: Not a visual change.
♿ Accessibility: Improves skip-to-content focus transfer reliability for keyboard and screen reader users navigating past the global navigation or hero headers.

---
*PR created automatically by Jules for task [13005913961501507437](https://jules.google.com/task/13005913961501507437) started by @ryusoh*