### PR TITLE
Code Health: Fix complexity and silent failure warnings

### DIFF
--- a/js/block-navigation.js
+++ b/js/block-navigation.js
@@ -328,16 +328,7 @@
         });
     }
 
-    function scrollToIndex(index) {
-        if (index < 0 || index >= blocks.length) {
-            return;
-        }
-
-        const target = blocks[index];
-        const isTopSentinel = topSentinel && target === topSentinel;
-        const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
-        const isFirstContentBlock = index <= (topSentinel ? 1 : 0);
-
+    function performScroll(target, isTopSentinel, behavior, isFirstContentBlock) {
         if (isTopSentinel) {
             window.scrollTo({ top: 0, behavior });
         } else {
@@ -348,10 +339,25 @@
                     inline: 'nearest',
                 });
             } catch (error) {
-                void error;
+                if (typeof window !== 'undefined' && window.console) {
+                    window.console.warn('[block-navigation] scrollIntoView failed, using fallback:', error);
+                }
                 scrollFallback(target, behavior, isFirstContentBlock);
             }
         }
+    }
+
+    function scrollToIndex(index) {
+        if (index < 0 || index >= blocks.length) {
+            return;
+        }
+
+        const target = blocks[index];
+        const isTopSentinel = topSentinel && target === topSentinel;
+        const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+        const isFirstContentBlock = index <= (topSentinel ? 1 : 0);
+
+        performScroll(target, isTopSentinel, behavior, isFirstContentBlock);
         startPending(index, behavior);
     }
 

--- a/js/page-transition.js
+++ b/js/page-transition.js
@@ -202,7 +202,15 @@ import * as THREE from './vendor/three.module.min.js';
                     return null;
                 }
             })
-            .catch(() => null); // Explicitly catch and silence html2canvas failures to fallback gracefully
+            .catch((e) => {
+                if (typeof window !== 'undefined' && window.console) {
+                    window.console.warn(
+                        '[page-transition] prepareDestinationTexture returned null',
+                        e
+                    );
+                }
+                return null;
+            }); // Explicitly catch and silence html2canvas failures to fallback gracefully
     }
 
     function loadTextureFromDataURL(dataUrl, THREE) {
@@ -463,7 +471,11 @@ import * as THREE from './vendor/three.module.min.js';
         }
 
         const prepareDestination = () => {
-            this.prepareDestinationTexture().catch(() => {});
+            this.prepareDestinationTexture().catch((e) => {
+                if (typeof window !== 'undefined' && window.console) {
+                    window.console.warn('[page-transition] prepareDestinationTexture failed', e);
+                }
+            });
         };
 
         if (document.readyState === 'complete') {
@@ -538,7 +550,11 @@ import * as THREE from './vendor/three.module.min.js';
                 this.uniforms.uTexture0.value = texture;
                 this.textures.previous = texture;
             })
-            .catch(() => {});
+            .catch((e) => {
+                if (typeof window !== 'undefined' && window.console) {
+                    window.console.warn('[page-transition] prepareDestinationTexture failed', e);
+                }
+            });
         return null;
     };
 
@@ -553,7 +569,15 @@ import * as THREE from './vendor/three.module.min.js';
                     this.textures.current = texture;
                     return texture;
                 })
-                .catch(() => null);
+                .catch((e) => {
+                    if (typeof window !== 'undefined' && window.console) {
+                        window.console.warn(
+                            '[page-transition] prepareDestinationTexture returned null',
+                            e
+                        );
+                    }
+                    return null;
+                });
         });
     };
 


### PR DESCRIPTION
This PR addresses the Scheduled Task for Code Health & Cleanup:
- **Module A (Structural Health):** Addressed a cyclomatic complexity failure (> 10) in `js/block-navigation.js` `scrollToIndex` by extracting logic into `performScroll`.
- **Module B (Resilience & Error Handling):** Located and refactored multiple empty/silent `catch` blocks in `js/page-transition.js` and `js/block-navigation.js` to log contextual warnings instead of hiding failures.
- **Module C (Code Hygiene):** Scanned for pending `TODO` items in the `css/`, `js/`, and source directories. None were found.
- All tests pass, and code has been checked against Prettier and ESLint.

Documentation was also updated in `.jules/sentinel.md` regarding these code health practices.

---
*PR created automatically by Jules for task [5349162451261765701](https://jules.google.com/task/5349162451261765701) started by @ryusoh*