### PR TITLE
🧪 Add coverage for document.createEvent fallback in emitEvent

### DIFF
--- a/tests/js/service-worker-register.test.js
+++ b/tests/js/service-worker-register.test.js
@@ -245,4 +245,63 @@ describe('service-worker-register', () => {
         );
         expect(context.window.dispatchEvent).toHaveBeenCalledWith(mockEvent);
     });
+
+    test('falls back to document.createEvent on registration failure', async () => {
+        delete context.window.CustomEvent;
+        delete context.CustomEvent;
+
+        context.navigator.serviceWorker.register.mockRejectedValue(
+            new Error('Registration failed')
+        );
+
+        const mockEvent = {
+            initCustomEvent: jest.fn(),
+        };
+        context.document.createEvent = jest.fn().mockReturnValue(mockEvent);
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        await new Promise(process.nextTick);
+
+        expect(context.document.createEvent).toHaveBeenCalledWith('CustomEvent');
+        expect(mockEvent.initCustomEvent).toHaveBeenCalledWith(
+            'serviceWorker:registrationError',
+            false,
+            false,
+            { message: 'Registration failed' }
+        );
+        expect(context.window.dispatchEvent).toHaveBeenCalledWith(mockEvent);
+    });
+
+    test('falls back to document.createEvent if window.CustomEvent is not a function', async () => {
+        context.window.CustomEvent = 'not-a-function';
+        delete context.CustomEvent;
+
+        const mockEvent = {
+            initCustomEvent: jest.fn(),
+        };
+        context.document.createEvent = jest.fn().mockReturnValue(mockEvent);
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        await new Promise(process.nextTick);
+
+        expect(context.document.createEvent).toHaveBeenCalledWith('CustomEvent');
+        expect(context.window.dispatchEvent).toHaveBeenCalledWith(mockEvent);
+    });
+
+    test('does not crash if both CustomEvent and document.createEvent are missing', async () => {
+        delete context.window.CustomEvent;
+        delete context.CustomEvent;
+        delete context.document.createEvent;
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        await new Promise(process.nextTick);
+
+        expect(context.window.dispatchEvent).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
The testing gap in `js/service-worker-register.js` regarding the legacy `document.createEvent` fallback path has been addressed.

🎯 **What:** The testing gap for the `emitEvent` fallback logic was identified. While `CustomEvent` was tested, the legacy path using `document.createEvent` and `initCustomEvent` lacked comprehensive coverage, especially for error scenarios.

📊 **Coverage:**
- Added a test case for `serviceWorker:registrationError` using the legacy fallback.
- Added a test case to verify that the script correctly falls back if `window.CustomEvent` exists but is not a function.
- Added a test case to ensure no crashes occur if both modern and legacy event creation methods are unavailable.

✨ **Result:** Test coverage for `emitEvent` in `js/service-worker-register.js` is now complete across all its logical branches. Verified that the tests correctly fail when the fallback logic is tampered with and pass with the correct implementation.


---
*PR created automatically by Jules for task [1412641111446038307](https://jules.google.com/task/1412641111446038307) started by @ryusoh*