### PR TITLE
test: add test coverage for loader scripts

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,3 +1,4 @@
 module.exports = {
     testEnvironment: 'node',
+    collectCoverageFrom: ['js/**/*.js', 'sw.js', '!js/vendor/**/*.js', '!js/**/*.min.js'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,31 @@
                 "@stylistic/stylelint-plugin": "^4.0.0",
                 "eslint": "^9.17.0",
                 "jest": "^29.7.0",
+                "jest-environment-jsdom": "^30.3.0",
                 "prettier": "^3.5.2",
                 "stylelint": "^16.22.0"
             }
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
+            }
+        },
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
@@ -572,6 +594,78 @@
                 "@keyv/serialize": "^1.1.1"
             }
         },
+        "node_modules/@csstools/color-helpers": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
         "node_modules/@csstools/css-parser-algorithms": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
@@ -1085,6 +1179,228 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/@jest/environment-jsdom-abstract": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+            "integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.3.0",
+                "@jest/fake-timers": "30.3.0",
+                "@jest/types": "30.3.0",
+                "@types/jsdom": "^21.1.7",
+                "@types/node": "*",
+                "jest-mock": "30.3.0",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+            "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/fake-timers": "30.3.0",
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "jest-mock": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+            "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@sinonjs/fake-timers": "^15.0.0",
+                "@types/node": "*",
+                "jest-message-util": "30.3.0",
+                "jest-mock": "30.3.0",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/schemas": {
+            "version": "30.0.5",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+            "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.34.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+            "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/pattern": "30.0.1",
+                "@jest/schemas": "30.0.5",
+                "@types/istanbul-lib-coverage": "^2.0.6",
+                "@types/istanbul-reports": "^3.0.4",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.33",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
+            "version": "0.34.48",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+            "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+            "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/ci-info": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+            "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@jest/types": "30.3.0",
+                "@types/stack-utils": "^2.0.3",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3",
+                "pretty-format": "30.3.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+            "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+            "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+            "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "30.0.5",
+                "ansi-styles": "^5.2.0",
+                "react-is": "^18.3.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
         "node_modules/@jest/expect": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
@@ -1144,6 +1460,30 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/pattern": {
+            "version": "30.0.1",
+            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+            "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "jest-regex-util": "30.0.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+            "version": "30.0.1",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+            "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/@jest/reporters": {
@@ -1528,6 +1868,18 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "node_modules/@types/jsdom": {
+            "version": "21.1.7",
+            "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+            "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/tough-cookie": "*",
+                "parse5": "^7.0.0"
+            }
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1549,6 +1901,13 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/tough-cookie": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
             "dev": true,
             "license": "MIT"
         },
@@ -1590,6 +1949,16 @@
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -2193,6 +2562,34 @@
                 "node": ">=4"
             }
         },
+        "node_modules/cssstyle": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^3.2.0",
+                "rrweb-cssom": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2210,6 +2607,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/dedent": {
             "version": "1.7.2",
@@ -2302,6 +2706,19 @@
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/env-paths": {
             "version": "2.2.1",
@@ -2968,6 +3385,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2988,6 +3418,34 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/human-signals": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -2996,6 +3454,19 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/ignore": {
@@ -3166,6 +3637,13 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
@@ -3469,6 +3947,223 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+            "integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.3.0",
+                "@jest/environment-jsdom-abstract": "30.3.0",
+                "jsdom": "^26.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+            "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/fake-timers": "30.3.0",
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "jest-mock": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+            "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@sinonjs/fake-timers": "^15.0.0",
+                "@types/node": "*",
+                "jest-message-util": "30.3.0",
+                "jest-mock": "30.3.0",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@jest/schemas": {
+            "version": "30.0.5",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+            "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.34.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+            "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/pattern": "30.0.1",
+                "@jest/schemas": "30.0.5",
+                "@types/istanbul-lib-coverage": "^2.0.6",
+                "@types/istanbul-reports": "^3.0.4",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.33",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
+            "version": "0.34.48",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+            "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+            "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/ci-info": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+            "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@jest/types": "30.3.0",
+                "@types/stack-utils": "^2.0.3",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3",
+                "pretty-format": "30.3.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/jest-mock": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+            "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/jest-util": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+            "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/jest-environment-jsdom/node_modules/pretty-format": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+            "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "30.0.5",
+                "ansi-styles": "^5.2.0",
+                "react-is": "^18.3.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-environment-node": {
@@ -3887,6 +4582,46 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsdom": {
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^5.1.1",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4243,6 +4978,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/nwsapi": {
+            "version": "2.2.23",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+            "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4359,6 +5101,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/path-exists": {
@@ -4822,6 +5577,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rrweb-cssom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4844,6 +5606,26 @@
             "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
             }
         },
         "node_modules/semver": {
@@ -5253,6 +6035,13 @@
             "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
             "dev": true
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/table": {
             "version": "6.9.0",
             "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -5309,6 +6098,26 @@
                 "node": ">=8"
             }
         },
+        "node_modules/tldts": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^6.1.86"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -5327,6 +6136,32 @@
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/type-check": {
@@ -5435,6 +6270,19 @@
                 "node": ">=10.12.0"
             }
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/walker": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -5443,6 +6291,54 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "makeerror": "1.0.12"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/which": {
@@ -5509,6 +6405,45 @@
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
+        },
+        "node_modules/ws": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@stylistic/stylelint-plugin": "^4.0.0",
         "eslint": "^9.17.0",
         "jest": "^29.7.0",
+        "jest-environment-jsdom": "^30.3.0",
         "prettier": "^3.5.2",
         "stylelint": "^16.22.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
             jest:
                 specifier: ^29.7.0
                 version: 29.7.0(@types/node@25.5.0)
+            jest-environment-jsdom:
+                specifier: ^30.3.0
+                version: 30.3.0
             prettier:
                 specifier: ^3.5.2
                 version: 3.8.1
@@ -24,6 +27,12 @@ importers:
                 version: 16.26.1
 
 packages:
+    '@asamuzakjp/css-color@3.2.0':
+        resolution:
+            {
+                integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==,
+            }
+
     '@babel/code-frame@7.29.0':
         resolution:
             {
@@ -306,6 +315,33 @@ packages:
                 integrity: sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==,
             }
 
+    '@csstools/color-helpers@5.1.0':
+        resolution:
+            {
+                integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==,
+            }
+        engines: { node: '>=18' }
+
+    '@csstools/css-calc@2.1.4':
+        resolution:
+            {
+                integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==,
+            }
+        engines: { node: '>=18' }
+        peerDependencies:
+            '@csstools/css-parser-algorithms': ^3.0.5
+            '@csstools/css-tokenizer': ^3.0.4
+
+    '@csstools/css-color-parser@3.1.0':
+        resolution:
+            {
+                integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==,
+            }
+        engines: { node: '>=18' }
+        peerDependencies:
+            '@csstools/css-parser-algorithms': ^3.0.5
+            '@csstools/css-tokenizer': ^3.0.4
+
     '@csstools/css-parser-algorithms@3.0.5':
         resolution:
             {
@@ -484,12 +520,32 @@ packages:
             node-notifier:
                 optional: true
 
+    '@jest/environment-jsdom-abstract@30.3.0':
+        resolution:
+            {
+                integrity: sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
+        peerDependencies:
+            canvas: ^3.0.0
+            jsdom: '*'
+        peerDependenciesMeta:
+            canvas:
+                optional: true
+
     '@jest/environment@29.7.0':
         resolution:
             {
                 integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==,
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/environment@30.3.0':
+        resolution:
+            {
+                integrity: sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
     '@jest/expect-utils@29.7.0':
         resolution:
@@ -512,12 +568,26 @@ packages:
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
 
+    '@jest/fake-timers@30.3.0':
+        resolution:
+            {
+                integrity: sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
+
     '@jest/globals@29.7.0':
         resolution:
             {
                 integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==,
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/pattern@30.0.1':
+        resolution:
+            {
+                integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
     '@jest/reporters@29.7.0':
         resolution:
@@ -537,6 +607,13 @@ packages:
                 integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==,
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/schemas@30.0.5':
+        resolution:
+            {
+                integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
     '@jest/source-map@29.6.3':
         resolution:
@@ -572,6 +649,13 @@ packages:
                 integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==,
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    '@jest/types@30.3.0':
+        resolution:
+            {
+                integrity: sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
     '@jridgewell/gen-mapping@0.3.13':
         resolution:
@@ -646,6 +730,12 @@ packages:
                 integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==,
             }
 
+    '@sinclair/typebox@0.34.48':
+        resolution:
+            {
+                integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==,
+            }
+
     '@sinonjs/commons@3.0.1':
         resolution:
             {
@@ -656,6 +746,12 @@ packages:
         resolution:
             {
                 integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==,
+            }
+
+    '@sinonjs/fake-timers@15.1.1':
+        resolution:
+            {
+                integrity: sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==,
             }
 
     '@stylistic/stylelint-plugin@4.0.1':
@@ -721,6 +817,12 @@ packages:
                 integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==,
             }
 
+    '@types/jsdom@21.1.7':
+        resolution:
+            {
+                integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==,
+            }
+
     '@types/json-schema@7.0.15':
         resolution:
             {
@@ -737,6 +839,12 @@ packages:
         resolution:
             {
                 integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==,
+            }
+
+    '@types/tough-cookie@4.0.5':
+        resolution:
+            {
+                integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==,
             }
 
     '@types/yargs-parser@21.0.3':
@@ -766,6 +874,13 @@ packages:
             }
         engines: { node: '>=0.4.0' }
         hasBin: true
+
+    agent-base@7.1.4:
+        resolution:
+            {
+                integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==,
+            }
+        engines: { node: '>= 14' }
 
     ajv@6.14.0:
         resolution:
@@ -987,6 +1102,13 @@ packages:
             }
         engines: { node: '>=8' }
 
+    ci-info@4.4.0:
+        resolution:
+            {
+                integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==,
+            }
+        engines: { node: '>=8' }
+
     cjs-module-lexer@1.4.3:
         resolution:
             {
@@ -1093,6 +1215,20 @@ packages:
         engines: { node: '>=4' }
         hasBin: true
 
+    cssstyle@4.6.0:
+        resolution:
+            {
+                integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==,
+            }
+        engines: { node: '>=18' }
+
+    data-urls@5.0.0:
+        resolution:
+            {
+                integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==,
+            }
+        engines: { node: '>=18' }
+
     debug@4.4.3:
         resolution:
             {
@@ -1104,6 +1240,12 @@ packages:
         peerDependenciesMeta:
             supports-color:
                 optional: true
+
+    decimal.js@10.6.0:
+        resolution:
+            {
+                integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==,
+            }
 
     dedent@1.7.2:
         resolution:
@@ -1168,6 +1310,13 @@ packages:
             {
                 integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
             }
+
+    entities@6.0.1:
+        resolution:
+            {
+                integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==,
+            }
+        engines: { node: '>=0.12' }
 
     env-paths@2.2.1:
         resolution:
@@ -1540,6 +1689,13 @@ packages:
                 integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==,
             }
 
+    html-encoding-sniffer@4.0.0:
+        resolution:
+            {
+                integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==,
+            }
+        engines: { node: '>=18' }
+
     html-escaper@2.0.2:
         resolution:
             {
@@ -1553,12 +1709,33 @@ packages:
             }
         engines: { node: '>=8' }
 
+    http-proxy-agent@7.0.2:
+        resolution:
+            {
+                integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==,
+            }
+        engines: { node: '>= 14' }
+
+    https-proxy-agent@7.0.6:
+        resolution:
+            {
+                integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
+            }
+        engines: { node: '>= 14' }
+
     human-signals@2.1.0:
         resolution:
             {
                 integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==,
             }
         engines: { node: '>=10.17.0' }
+
+    iconv-lite@0.6.3:
+        resolution:
+            {
+                integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==,
+            }
+        engines: { node: '>=0.10.0' }
 
     ignore@5.3.2:
         resolution:
@@ -1669,6 +1846,12 @@ packages:
                 integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==,
             }
         engines: { node: '>=0.10.0' }
+
+    is-potential-custom-element-name@1.0.1:
+        resolution:
+            {
+                integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==,
+            }
 
     is-stream@2.0.1:
         resolution:
@@ -1788,6 +1971,18 @@ packages:
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
 
+    jest-environment-jsdom@30.3.0:
+        resolution:
+            {
+                integrity: sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
+        peerDependencies:
+            canvas: ^3.0.0
+        peerDependenciesMeta:
+            canvas:
+                optional: true
+
     jest-environment-node@29.7.0:
         resolution:
             {
@@ -1830,12 +2025,26 @@ packages:
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
 
+    jest-message-util@30.3.0:
+        resolution:
+            {
+                integrity: sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
+
     jest-mock@29.7.0:
         resolution:
             {
                 integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==,
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-mock@30.3.0:
+        resolution:
+            {
+                integrity: sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
     jest-pnp-resolver@1.2.3:
         resolution:
@@ -1855,6 +2064,13 @@ packages:
                 integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==,
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-regex-util@30.0.1:
+        resolution:
+            {
+                integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
     jest-resolve-dependencies@29.7.0:
         resolution:
@@ -1897,6 +2113,13 @@ packages:
                 integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==,
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    jest-util@30.3.0:
+        resolution:
+            {
+                integrity: sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
     jest-validate@29.7.0:
         resolution:
@@ -1951,6 +2174,18 @@ packages:
                 integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
             }
         hasBin: true
+
+    jsdom@26.1.0:
+        resolution:
+            {
+                integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==,
+            }
+        engines: { node: '>=18' }
+        peerDependencies:
+            canvas: ^3.0.0
+        peerDependenciesMeta:
+            canvas:
+                optional: true
 
     jsesc@3.1.0:
         resolution:
@@ -2076,6 +2311,12 @@ packages:
                 integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==,
             }
 
+    lru-cache@10.4.3:
+        resolution:
+            {
+                integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
+            }
+
     lru-cache@5.1.1:
         resolution:
             {
@@ -2193,6 +2434,12 @@ packages:
             }
         engines: { node: '>=8' }
 
+    nwsapi@2.2.23:
+        resolution:
+            {
+                integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==,
+            }
+
     once@1.4.0:
         resolution:
             {
@@ -2262,6 +2509,12 @@ packages:
             }
         engines: { node: '>=8' }
 
+    parse5@7.3.0:
+        resolution:
+            {
+                integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==,
+            }
+
     path-exists@4.0.0:
         resolution:
             {
@@ -2308,6 +2561,13 @@ packages:
                 integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
             }
         engines: { node: '>=8.6' }
+
+    picomatch@4.0.3:
+        resolution:
+            {
+                integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+            }
+        engines: { node: '>=12' }
 
     pirates@4.0.7:
         resolution:
@@ -2379,6 +2639,13 @@ packages:
                 integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==,
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    pretty-format@30.3.0:
+        resolution:
+            {
+                integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==,
+            }
+        engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
     prompts@2.4.2:
         resolution:
@@ -2476,11 +2743,30 @@ packages:
             }
         engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
 
+    rrweb-cssom@0.8.0:
+        resolution:
+            {
+                integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==,
+            }
+
     run-parallel@1.2.0:
         resolution:
             {
                 integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
             }
+
+    safer-buffer@2.1.2:
+        resolution:
+            {
+                integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+            }
+
+    saxes@6.0.0:
+        resolution:
+            {
+                integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==,
+            }
+        engines: { node: '>=v12.22.7' }
 
     semver@6.3.1:
         resolution:
@@ -2667,6 +2953,12 @@ packages:
                 integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==,
             }
 
+    symbol-tree@3.2.4:
+        resolution:
+            {
+                integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==,
+            }
+
     table@6.9.0:
         resolution:
             {
@@ -2681,6 +2973,19 @@ packages:
             }
         engines: { node: '>=8' }
 
+    tldts-core@6.1.86:
+        resolution:
+            {
+                integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==,
+            }
+
+    tldts@6.1.86:
+        resolution:
+            {
+                integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==,
+            }
+        hasBin: true
+
     tmpl@1.0.5:
         resolution:
             {
@@ -2693,6 +2998,20 @@ packages:
                 integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
             }
         engines: { node: '>=8.0' }
+
+    tough-cookie@5.1.2:
+        resolution:
+            {
+                integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==,
+            }
+        engines: { node: '>=16' }
+
+    tr46@5.1.1:
+        resolution:
+            {
+                integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==,
+            }
+        engines: { node: '>=18' }
 
     type-check@0.4.0:
         resolution:
@@ -2749,11 +3068,47 @@ packages:
             }
         engines: { node: '>=10.12.0' }
 
+    w3c-xmlserializer@5.0.0:
+        resolution:
+            {
+                integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==,
+            }
+        engines: { node: '>=18' }
+
     walker@1.0.8:
         resolution:
             {
                 integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==,
             }
+
+    webidl-conversions@7.0.0:
+        resolution:
+            {
+                integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==,
+            }
+        engines: { node: '>=12' }
+
+    whatwg-encoding@3.1.1:
+        resolution:
+            {
+                integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==,
+            }
+        engines: { node: '>=18' }
+        deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+    whatwg-mimetype@4.0.0:
+        resolution:
+            {
+                integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==,
+            }
+        engines: { node: '>=18' }
+
+    whatwg-url@14.2.0:
+        resolution:
+            {
+                integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==,
+            }
+        engines: { node: '>=18' }
 
     which@1.3.1:
         resolution:
@@ -2804,6 +3159,34 @@ packages:
             }
         engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
 
+    ws@8.20.0:
+        resolution:
+            {
+                integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==,
+            }
+        engines: { node: '>=10.0.0' }
+        peerDependencies:
+            bufferutil: ^4.0.1
+            utf-8-validate: '>=5.0.2'
+        peerDependenciesMeta:
+            bufferutil:
+                optional: true
+            utf-8-validate:
+                optional: true
+
+    xml-name-validator@5.0.0:
+        resolution:
+            {
+                integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==,
+            }
+        engines: { node: '>=18' }
+
+    xmlchars@2.2.0:
+        resolution:
+            {
+                integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==,
+            }
+
     y18n@5.0.8:
         resolution:
             {
@@ -2839,6 +3222,14 @@ packages:
         engines: { node: '>=10' }
 
 snapshots:
+    '@asamuzakjp/css-color@3.2.0':
+        dependencies:
+            '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+            '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+            '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+            '@csstools/css-tokenizer': 3.0.4
+            lru-cache: 10.4.3
+
     '@babel/code-frame@7.29.0':
         dependencies:
             '@babel/helper-validator-identifier': 7.28.5
@@ -3040,6 +3431,20 @@ snapshots:
             hashery: 1.5.0
             keyv: 5.6.0
 
+    '@csstools/color-helpers@5.1.0': {}
+
+    '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+        dependencies:
+            '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+            '@csstools/css-tokenizer': 3.0.4
+
+    '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+        dependencies:
+            '@csstools/color-helpers': 5.1.0
+            '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+            '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+            '@csstools/css-tokenizer': 3.0.4
+
     '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
         dependencies:
             '@csstools/css-tokenizer': 3.0.4
@@ -3172,12 +3577,30 @@ snapshots:
             - supports-color
             - ts-node
 
+    '@jest/environment-jsdom-abstract@30.3.0(jsdom@26.1.0)':
+        dependencies:
+            '@jest/environment': 30.3.0
+            '@jest/fake-timers': 30.3.0
+            '@jest/types': 30.3.0
+            '@types/jsdom': 21.1.7
+            '@types/node': 25.5.0
+            jest-mock: 30.3.0
+            jest-util: 30.3.0
+            jsdom: 26.1.0
+
     '@jest/environment@29.7.0':
         dependencies:
             '@jest/fake-timers': 29.7.0
             '@jest/types': 29.6.3
             '@types/node': 25.5.0
             jest-mock: 29.7.0
+
+    '@jest/environment@30.3.0':
+        dependencies:
+            '@jest/fake-timers': 30.3.0
+            '@jest/types': 30.3.0
+            '@types/node': 25.5.0
+            jest-mock: 30.3.0
 
     '@jest/expect-utils@29.7.0':
         dependencies:
@@ -3199,6 +3622,15 @@ snapshots:
             jest-mock: 29.7.0
             jest-util: 29.7.0
 
+    '@jest/fake-timers@30.3.0':
+        dependencies:
+            '@jest/types': 30.3.0
+            '@sinonjs/fake-timers': 15.1.1
+            '@types/node': 25.5.0
+            jest-message-util: 30.3.0
+            jest-mock: 30.3.0
+            jest-util: 30.3.0
+
     '@jest/globals@29.7.0':
         dependencies:
             '@jest/environment': 29.7.0
@@ -3207,6 +3639,11 @@ snapshots:
             jest-mock: 29.7.0
         transitivePeerDependencies:
             - supports-color
+
+    '@jest/pattern@30.0.1':
+        dependencies:
+            '@types/node': 25.5.0
+            jest-regex-util: 30.0.1
 
     '@jest/reporters@29.7.0':
         dependencies:
@@ -3240,6 +3677,10 @@ snapshots:
     '@jest/schemas@29.6.3':
         dependencies:
             '@sinclair/typebox': 0.27.10
+
+    '@jest/schemas@30.0.5':
+        dependencies:
+            '@sinclair/typebox': 0.34.48
 
     '@jest/source-map@29.6.3':
         dependencies:
@@ -3290,6 +3731,16 @@ snapshots:
             '@types/yargs': 17.0.35
             chalk: 4.1.2
 
+    '@jest/types@30.3.0':
+        dependencies:
+            '@jest/pattern': 30.0.1
+            '@jest/schemas': 30.0.5
+            '@types/istanbul-lib-coverage': 2.0.6
+            '@types/istanbul-reports': 3.0.4
+            '@types/node': 25.5.0
+            '@types/yargs': 17.0.35
+            chalk: 4.1.2
+
     '@jridgewell/gen-mapping@0.3.13':
         dependencies:
             '@jridgewell/sourcemap-codec': 1.5.5
@@ -3331,11 +3782,17 @@ snapshots:
 
     '@sinclair/typebox@0.27.10': {}
 
+    '@sinclair/typebox@0.34.48': {}
+
     '@sinonjs/commons@3.0.1':
         dependencies:
             type-detect: 4.0.8
 
     '@sinonjs/fake-timers@10.3.0':
+        dependencies:
+            '@sinonjs/commons': 3.0.1
+
+    '@sinonjs/fake-timers@15.1.1':
         dependencies:
             '@sinonjs/commons': 3.0.1
 
@@ -3387,6 +3844,12 @@ snapshots:
         dependencies:
             '@types/istanbul-lib-report': 3.0.3
 
+    '@types/jsdom@21.1.7':
+        dependencies:
+            '@types/node': 25.5.0
+            '@types/tough-cookie': 4.0.5
+            parse5: 7.3.0
+
     '@types/json-schema@7.0.15': {}
 
     '@types/node@25.5.0':
@@ -3394,6 +3857,8 @@ snapshots:
             undici-types: 7.18.2
 
     '@types/stack-utils@2.0.3': {}
+
+    '@types/tough-cookie@4.0.5': {}
 
     '@types/yargs-parser@21.0.3': {}
 
@@ -3406,6 +3871,8 @@ snapshots:
             acorn: 8.16.0
 
     acorn@8.16.0: {}
+
+    agent-base@7.1.4: {}
 
     ajv@6.14.0:
         dependencies:
@@ -3557,6 +4024,8 @@ snapshots:
 
     ci-info@3.9.0: {}
 
+    ci-info@4.4.0: {}
+
     cjs-module-lexer@1.4.3: {}
 
     cliui@8.0.1:
@@ -3618,9 +4087,21 @@ snapshots:
 
     cssesc@3.0.0: {}
 
+    cssstyle@4.6.0:
+        dependencies:
+            '@asamuzakjp/css-color': 3.2.0
+            rrweb-cssom: 0.8.0
+
+    data-urls@5.0.0:
+        dependencies:
+            whatwg-mimetype: 4.0.0
+            whatwg-url: 14.2.0
+
     debug@4.4.3:
         dependencies:
             ms: 2.1.3
+
+    decimal.js@10.6.0: {}
 
     dedent@1.7.2: {}
 
@@ -3641,6 +4122,8 @@ snapshots:
     emittery@0.13.1: {}
 
     emoji-regex@8.0.0: {}
+
+    entities@6.0.1: {}
 
     env-paths@2.2.1: {}
 
@@ -3874,11 +4357,33 @@ snapshots:
 
     hookified@1.15.1: {}
 
+    html-encoding-sniffer@4.0.0:
+        dependencies:
+            whatwg-encoding: 3.1.1
+
     html-escaper@2.0.2: {}
 
     html-tags@3.3.1: {}
 
+    http-proxy-agent@7.0.2:
+        dependencies:
+            agent-base: 7.1.4
+            debug: 4.4.3
+        transitivePeerDependencies:
+            - supports-color
+
+    https-proxy-agent@7.0.6:
+        dependencies:
+            agent-base: 7.1.4
+            debug: 4.4.3
+        transitivePeerDependencies:
+            - supports-color
+
     human-signals@2.1.0: {}
+
+    iconv-lite@0.6.3:
+        dependencies:
+            safer-buffer: 2.1.2
 
     ignore@5.3.2: {}
 
@@ -3924,6 +4429,8 @@ snapshots:
     is-number@7.0.0: {}
 
     is-plain-object@5.0.0: {}
+
+    is-potential-custom-element-name@1.0.1: {}
 
     is-stream@2.0.1: {}
 
@@ -4070,6 +4577,16 @@ snapshots:
             jest-util: 29.7.0
             pretty-format: 29.7.0
 
+    jest-environment-jsdom@30.3.0:
+        dependencies:
+            '@jest/environment': 30.3.0
+            '@jest/environment-jsdom-abstract': 30.3.0(jsdom@26.1.0)
+            jsdom: 26.1.0
+        transitivePeerDependencies:
+            - bufferutil
+            - supports-color
+            - utf-8-validate
+
     jest-environment-node@29.7.0:
         dependencies:
             '@jest/environment': 29.7.0
@@ -4121,17 +4638,37 @@ snapshots:
             slash: 3.0.0
             stack-utils: 2.0.6
 
+    jest-message-util@30.3.0:
+        dependencies:
+            '@babel/code-frame': 7.29.0
+            '@jest/types': 30.3.0
+            '@types/stack-utils': 2.0.3
+            chalk: 4.1.2
+            graceful-fs: 4.2.11
+            picomatch: 4.0.3
+            pretty-format: 30.3.0
+            slash: 3.0.0
+            stack-utils: 2.0.6
+
     jest-mock@29.7.0:
         dependencies:
             '@jest/types': 29.6.3
             '@types/node': 25.5.0
             jest-util: 29.7.0
 
+    jest-mock@30.3.0:
+        dependencies:
+            '@jest/types': 30.3.0
+            '@types/node': 25.5.0
+            jest-util: 30.3.0
+
     jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
         optionalDependencies:
             jest-resolve: 29.7.0
 
     jest-regex-util@29.6.3: {}
+
+    jest-regex-util@30.0.1: {}
 
     jest-resolve-dependencies@29.7.0:
         dependencies:
@@ -4239,6 +4776,15 @@ snapshots:
             graceful-fs: 4.2.11
             picomatch: 2.3.1
 
+    jest-util@30.3.0:
+        dependencies:
+            '@jest/types': 30.3.0
+            '@types/node': 25.5.0
+            chalk: 4.1.2
+            ci-info: 4.4.0
+            graceful-fs: 4.2.11
+            picomatch: 4.0.3
+
     jest-validate@29.7.0:
         dependencies:
             '@jest/types': 29.6.3
@@ -4289,6 +4835,33 @@ snapshots:
         dependencies:
             argparse: 2.0.1
 
+    jsdom@26.1.0:
+        dependencies:
+            cssstyle: 4.6.0
+            data-urls: 5.0.0
+            decimal.js: 10.6.0
+            html-encoding-sniffer: 4.0.0
+            http-proxy-agent: 7.0.2
+            https-proxy-agent: 7.0.6
+            is-potential-custom-element-name: 1.0.1
+            nwsapi: 2.2.23
+            parse5: 7.3.0
+            rrweb-cssom: 0.8.0
+            saxes: 6.0.0
+            symbol-tree: 3.2.4
+            tough-cookie: 5.1.2
+            w3c-xmlserializer: 5.0.0
+            webidl-conversions: 7.0.0
+            whatwg-encoding: 3.1.1
+            whatwg-mimetype: 4.0.0
+            whatwg-url: 14.2.0
+            ws: 8.20.0
+            xml-name-validator: 5.0.0
+        transitivePeerDependencies:
+            - bufferutil
+            - supports-color
+            - utf-8-validate
+
     jsesc@3.1.0: {}
 
     json-buffer@3.0.1: {}
@@ -4337,6 +4910,8 @@ snapshots:
     lodash.merge@4.6.2: {}
 
     lodash.truncate@4.4.2: {}
+
+    lru-cache@10.4.3: {}
 
     lru-cache@5.1.1:
         dependencies:
@@ -4387,6 +4962,8 @@ snapshots:
         dependencies:
             path-key: 3.1.1
 
+    nwsapi@2.2.23: {}
+
     once@1.4.0:
         dependencies:
             wrappy: 1.0.2
@@ -4433,6 +5010,10 @@ snapshots:
             json-parse-even-better-errors: 2.3.1
             lines-and-columns: 1.2.4
 
+    parse5@7.3.0:
+        dependencies:
+            entities: 6.0.1
+
     path-exists@4.0.0: {}
 
     path-is-absolute@1.0.1: {}
@@ -4446,6 +5027,8 @@ snapshots:
     picocolors@1.1.1: {}
 
     picomatch@2.3.1: {}
+
+    picomatch@4.0.3: {}
 
     pirates@4.0.7: {}
 
@@ -4479,6 +5062,12 @@ snapshots:
     pretty-format@29.7.0:
         dependencies:
             '@jest/schemas': 29.6.3
+            ansi-styles: 5.2.0
+            react-is: 18.3.1
+
+    pretty-format@30.3.0:
+        dependencies:
+            '@jest/schemas': 30.0.5
             ansi-styles: 5.2.0
             react-is: 18.3.1
 
@@ -4521,9 +5110,17 @@ snapshots:
 
     reusify@1.1.0: {}
 
+    rrweb-cssom@0.8.0: {}
+
     run-parallel@1.2.0:
         dependencies:
             queue-microtask: 1.2.3
+
+    safer-buffer@2.1.2: {}
+
+    saxes@6.0.0:
+        dependencies:
+            xmlchars: 2.2.0
 
     semver@6.3.1: {}
 
@@ -4649,6 +5246,8 @@ snapshots:
 
     svg-tags@1.0.0: {}
 
+    symbol-tree@3.2.4: {}
+
     table@6.9.0:
         dependencies:
             ajv: 8.18.0
@@ -4663,11 +5262,25 @@ snapshots:
             glob: 7.2.3
             minimatch: 3.1.5
 
+    tldts-core@6.1.86: {}
+
+    tldts@6.1.86:
+        dependencies:
+            tldts-core: 6.1.86
+
     tmpl@1.0.5: {}
 
     to-regex-range@5.0.1:
         dependencies:
             is-number: 7.0.0
+
+    tough-cookie@5.1.2:
+        dependencies:
+            tldts: 6.1.86
+
+    tr46@5.1.1:
+        dependencies:
+            punycode: 2.3.1
 
     type-check@0.4.0:
         dependencies:
@@ -4697,9 +5310,26 @@ snapshots:
             '@types/istanbul-lib-coverage': 2.0.6
             convert-source-map: 2.0.0
 
+    w3c-xmlserializer@5.0.0:
+        dependencies:
+            xml-name-validator: 5.0.0
+
     walker@1.0.8:
         dependencies:
             makeerror: 1.0.12
+
+    webidl-conversions@7.0.0: {}
+
+    whatwg-encoding@3.1.1:
+        dependencies:
+            iconv-lite: 0.6.3
+
+    whatwg-mimetype@4.0.0: {}
+
+    whatwg-url@14.2.0:
+        dependencies:
+            tr46: 5.1.1
+            webidl-conversions: 7.0.0
 
     which@1.3.1:
         dependencies:
@@ -4728,6 +5358,12 @@ snapshots:
         dependencies:
             imurmurhash: 0.1.4
             signal-exit: 4.1.0
+
+    ws@8.20.0: {}
+
+    xml-name-validator@5.0.0: {}
+
+    xmlchars@2.2.0: {}
 
     y18n@5.0.8: {}
 

--- a/tests/js/ambient/loader.test.js
+++ b/tests/js/ambient/loader.test.js
@@ -48,6 +48,17 @@ describe('ambient/loader.js', () => {
         expect(mockCDNLoader.loadCssWithFallback).not.toHaveBeenCalled();
     });
 
+    test('handles missing window.matchMedia gracefully', () => {
+        delete context.window.matchMedia;
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        expect(mockCDNLoader.loadCssWithFallback).toHaveBeenCalledWith([
+            '/css/ambient/ambient.css',
+        ]);
+    });
+
     test('exits early if window innerWidth is less than 1024', () => {
         context.window.innerWidth = 800;
 
@@ -140,6 +151,20 @@ describe('ambient/loader.js', () => {
             'Ambient async loader failed:',
             expect.any(Error)
         );
+    });
+
+    test('ignores promise rejections from CDNLoader without throwing when console.warn is missing', async () => {
+        delete context.window.console.warn;
+        mockCDNLoader.loadCssWithFallback.mockRejectedValue(new Error('Simulated network error'));
+
+        vm.createContext(context);
+
+        expect(() => {
+            vm.runInContext(code, context);
+        }).not.toThrow();
+
+        await new Promise(process.nextTick);
+        await new Promise(process.nextTick);
     });
 
     test('ignores synchronous errors during initialization gracefully and logs warning', () => {

--- a/tests/js/loader/cdnFallback.test.js
+++ b/tests/js/loader/cdnFallback.test.js
@@ -76,6 +76,22 @@ describe('CDNLoader', () => {
         loader = context.window.CDNLoader;
     });
 
+    describe('initialization', () => {
+        it('should exit early if window.CDNLoader already exists', () => {
+            const existingLoader = { preconnect: jest.fn() };
+            const customContext = {
+                window: {
+                    CDNLoader: existingLoader,
+                },
+            };
+            vm.createContext(customContext);
+            vm.runInContext(code, customContext);
+
+            // It should not have been overwritten
+            expect(customContext.window.CDNLoader).toBe(existingLoader);
+        });
+    });
+
     describe('preconnect', () => {
         it('should append link elements for each origin', () => {
             const origins = ['https://fonts.googleapis.com', 'https://fonts.gstatic.com'];


### PR DESCRIPTION
Configured global Jest test coverage matching across the repository and successfully identified and addressed three test coverage gaps inside the `ambient/loader.js` and `loader/cdnFallback.js` utility scripts as evaluated in isolated Node VM contexts.

---
*PR created automatically by Jules for task [15005015968911402261](https://jules.google.com/task/15005015968911402261) started by @ryusoh*