### PR TITLE
🎨 Palette: Enhance Skip-to-content Visual UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -27,3 +27,8 @@
 
 **Learning:** "Skip to content" links (with visually hidden `.sr-only` classes) are great for keyboard users, but if the target element (like `<main id="main">`) is not inherently focusable, some browsers will scroll the viewport but fail to move the actual focus. When the user presses Tab again, focus jumps back to the top of the page.
 **Action:** Always add `tabindex="-1"` to the target element of a skip link. This makes the element programmatically focusable without adding it to the normal tab order, ensuring focus is reliably transferred so the next Tab keypress moves into the main content.
+
+## 2026-11-21 - [Accessibility: Styling Skip-to-content Links and Suppressing Main Outline]
+
+**Learning:** When a "Skip to content" link uses `.sr-only-focusable` to appear upon keyboard focus, reverting simply to `position: static` without additional styling causes the link to appear as plain text, often disrupting page layout and offering a poor user experience. Additionally, when focus is programmatically transferred to the target container (e.g., `<main tabindex="-1">`) via the skip link, some browsers display a massive, distracting default focus ring around the entire container because the focus was initiated by a keyboard interaction.
+**Action:** Style `.sr-only-focusable:focus` to appear as a highly visible, absolutely positioned overlay button (e.g., using a bright background color, padding, and `z-index`) so it doesn't shift the surrounding layout. Furthermore, globally append `[tabindex="-1"]:focus { outline: none !important; }` to CSS resets to suppress the focus ring on non-interactive target containers.

--- a/css/main_style.css
+++ b/css/main_style.css
@@ -480,12 +480,21 @@ footer {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-    position: static;
+    position: absolute;
+    top: 10px;
+    left: 10px;
     width: auto;
     height: auto;
     margin: 0;
+    padding: 10px 15px;
+    background-color: #ce2323;
+    color: #fff;
+    font-weight: bold;
+    border-radius: 4px;
+    z-index: 10000;
     overflow: visible;
     clip: auto;
+    text-decoration: none;
 }
 
 /* Global focus-visible for accessibility */
@@ -494,4 +503,9 @@ footer {
     outline-offset: 4px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
     border-radius: 2px;
+}
+
+/* Remove default focus outline for programmatic focus targets */
+[tabindex='-1']:focus {
+    outline: none !important;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1106,12 +1106,21 @@ td {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-    position: static;
+    position: absolute;
+    top: 10px;
+    left: 10px;
     width: auto;
     height: auto;
     margin: 0;
+    padding: 10px 15px;
+    background-color: #ce2323;
+    color: #fff;
+    font-weight: bold;
+    border-radius: 4px;
+    z-index: 10000;
     overflow: visible;
     clip: auto;
+    text-decoration: none;
 }
 
 /* Global focus-visible for accessibility */
@@ -1120,4 +1129,9 @@ td {
     outline-offset: 4px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
     border-radius: 2px;
+}
+
+/* Remove default focus outline for programmatic focus targets */
+[tabindex='-1']:focus {
+    outline: none !important;
 }


### PR DESCRIPTION
💡 **What**:
- Styled `.sr-only-focusable:focus` elements with absolute positioning, clear background/text colors, and padding to render as an accessible button overlay.
- Added `[tabindex="-1"]:focus { outline: none !important; }` globally.

🎯 **Why**:
- Previously, tabbing to the "Skip to content" link just reverted it to an unstyled inline element (using `position: static`), causing an abrupt layout shift and providing a poor, unpolished visual experience.
- When the user activated the link, focus programmatically jumped to the `<main tabindex="-1">` target element. Since the action was initiated by a keyboard `Enter` press, modern browsers would draw a massive focus ring around the entire main content area, which is highly distracting.

📸 **Before/After**:
Before: Unstyled link, massive outline box around content.
After: Professional overlay button for the skip link, seamless transfer of focus without global outline artifact.

♿ **Accessibility**:
- Vastly improves the keyboard navigation workflow for keyboard-reliant users. The user is now clearly informed of their context using a contrasting button overlay, and programmatic focus transfers do not visually pollute the page with unexpected browser-level outlines.

---
*PR created automatically by Jules for task [16135929488558910795](https://jules.google.com/task/16135929488558910795) started by @ryusoh*