### PR TITLE
🎨 Palette: [Accessibility] Improve skip-to-content focus visibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -27,3 +27,8 @@
 
 **Learning:** "Skip to content" links (with visually hidden `.sr-only` classes) are great for keyboard users, but if the target element (like `<main id="main">`) is not inherently focusable, some browsers will scroll the viewport but fail to move the actual focus. When the user presses Tab again, focus jumps back to the top of the page.
 **Action:** Always add `tabindex="-1"` to the target element of a skip link. This makes the element programmatically focusable without adding it to the normal tab order, ensuring focus is reliably transferred so the next Tab keypress moves into the main content.
+
+## 2025-02-28 - [Accessibility: Skip-to-content Visibility]
+
+**Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
+**Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.

--- a/css/main_style.css
+++ b/css/main_style.css
@@ -480,7 +480,14 @@ footer {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-    position: static;
+    position: absolute;
+    z-index: 9999;
+    background-color: #fff;
+    color: #000;
+    padding: 10px 15px;
+    border-radius: 0 0 4px 0;
+    top: 0;
+    left: 0;
     width: auto;
     height: auto;
     margin: 0;
@@ -494,4 +501,9 @@ footer {
     outline-offset: 4px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
     border-radius: 2px;
+}
+
+/* Hide default focus ring on programmatically focusable elements (like <main>) */
+[tabindex='-1']:focus {
+    outline: none !important;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1106,7 +1106,14 @@ td {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-    position: static;
+    position: absolute;
+    z-index: 9999;
+    background-color: #fff;
+    color: #000;
+    padding: 10px 15px;
+    border-radius: 0 0 4px 0;
+    top: 0;
+    left: 0;
     width: auto;
     height: auto;
     margin: 0;
@@ -1120,4 +1127,9 @@ td {
     outline-offset: 4px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
     border-radius: 2px;
+}
+
+/* Hide default focus ring on programmatically focusable elements (like <main>) */
+[tabindex='-1']:focus {
+    outline: none !important;
 }


### PR DESCRIPTION
* 💡 What: The UX enhancement changes the `:focus` state of the `.sr-only-focusable` (Skip to content) link to `position: absolute` with a high `z-index`, contrasting colors, and explicit padding. It also adds `outline: none !important;` to `[tabindex="-1"]:focus`.
* 🎯 Why: When a keyboard user tabs to the "Skip to content" link, the old `position: static` behavior caused the entire page layout to instantly jar downwards to accommodate the newly visible element. Changing it to an absolute overlay solves this layout shift. Additionally, removing the focus ring on `[tabindex="-1"]` targets prevents the browser from drawing a massive, distracting outline around the entire `<main>` container when focus is programmatically shifted.
* 📸 Before/After: Verified visually via Playwright headless scripts, ensuring the link floats beautifully in the top-left corner and the main area focuses cleanly.
* ♿ Accessibility: Specifically addresses WCAG guidelines for Focus Visible by ensuring focus indicators are clear without causing disorienting layout shifts for keyboard navigation users.

Journaled learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [14981548536921965603](https://jules.google.com/task/14981548536921965603) started by @ryusoh*