### PR TITLE
Palette: Enhance skip to content link accessibility

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -480,12 +480,23 @@ footer {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-    position: static;
+    position: absolute;
     width: auto;
     height: auto;
     margin: 0;
     overflow: visible;
     clip: auto;
+    z-index: 9999;
+    top: 0;
+    left: 0;
+    padding: 10px;
+    background: #ce2323;
+    color: #fff;
+    text-decoration: none;
+}
+
+[tabindex='-1']:focus {
+    outline: none !important;
 }
 
 /* Global focus-visible for accessibility */

--- a/css/style.css
+++ b/css/style.css
@@ -1106,12 +1106,23 @@ td {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-    position: static;
+    position: absolute;
     width: auto;
     height: auto;
     margin: 0;
     overflow: visible;
     clip: auto;
+    z-index: 9999;
+    top: 0;
+    left: 0;
+    padding: 10px;
+    background: #ce2323;
+    color: #fff;
+    text-decoration: none;
+}
+
+[tabindex='-1']:focus {
+    outline: none !important;
 }
 
 /* Global focus-visible for accessibility */


### PR DESCRIPTION
Palette: Enhance skip to content link accessibility

What: Added proper absolute positioning and high-contrast styling (red background with white text) to the `.sr-only-focusable:focus` selector. Additionally, removed the default focus ring for any layout elements utilizing `tabindex="-1"`.
Why: The skip to content link was previously functioning but lacked visual indicators or position management, disrupting the document flow and lacking visibility for sighted users traversing with a keyboard. Further, the `<main>` container would undesirably highlight with a native focus ring when keyboard focus transitioned to it, making the UI appear confusing.
Accessibility: Directly improves keyboard navigation flow, removes jarring layout shifts when skip links become visible, and provides essential visual feedback for accessible users.

Files modified:
- css/main_style.css
- css/style.css

---
*PR created automatically by Jules for task [17940492608614405098](https://jules.google.com/task/17940492608614405098) started by @ryusoh*