### PR TITLE
Palette: Improve skip-to-content accessibility styling

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -480,12 +480,24 @@ footer {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-    position: static;
+    position: absolute;
     width: auto;
     height: auto;
     margin: 0;
     overflow: visible;
     clip: auto;
+    z-index: 9999;
+    background-color: #000;
+    color: #fff;
+    padding: 10px;
+    border: 2px solid #ce2323;
+    border-radius: 4px;
+    top: 10px;
+    left: 10px;
+}
+
+[tabindex='-1']:focus {
+    outline: none !important;
 }
 
 /* Global focus-visible for accessibility */

--- a/css/style.css
+++ b/css/style.css
@@ -1106,12 +1106,24 @@ td {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-    position: static;
+    position: absolute;
     width: auto;
     height: auto;
     margin: 0;
     overflow: visible;
     clip: auto;
+    z-index: 9999;
+    background-color: #000;
+    color: #fff;
+    padding: 10px;
+    border: 2px solid #ce2323;
+    border-radius: 4px;
+    top: 10px;
+    left: 10px;
+}
+
+[tabindex='-1']:focus {
+    outline: none !important;
 }
 
 /* Global focus-visible for accessibility */


### PR DESCRIPTION
💡 What: The UX enhancement added explicit absolute positioning, padding, explicit background and text color, a red border and a high z-index to the `.sr-only-focusable:active` and `.sr-only-focusable:focus` styles so that the "Skip to content" links are highly visible to keyboard users. It also adds `outline: none !important;` to the `[tabindex="-1"]` container (the `<main>` element) to prevent an unsightly default focus ring around the whole layout when the skip link brings focus there.
🎯 Why: "Skip to content" links are crucial for keyboard navigation, allowing users to bypass repetitive navigation. Without visual styling on focus, users wouldn't know the link is there or when it's focused. Removing the default outline on the target `<main>` prevents distracting layout outlines.
♿ Accessibility: The explicit overlay styling ensures skip-to-content links don't shift surrounding layout while providing high visual contrast for keyboard and screen reader users navigating the page content.

---
*PR created automatically by Jules for task [10821851866482664012](https://jules.google.com/task/10821851866482664012) started by @ryusoh*