### PR TITLE
🎨 Palette: Remove focus ring from non-interactive layout containers

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -488,6 +488,10 @@ footer {
     clip: auto;
 }
 
+[tabindex='-1']:focus {
+    outline: none !important;
+}
+
 /* Global focus-visible for accessibility */
 :focus-visible {
     outline: 2px solid rgba(206, 35, 35, 0.8) !important;

--- a/css/style.css
+++ b/css/style.css
@@ -1114,6 +1114,10 @@ td {
     clip: auto;
 }
 
+[tabindex='-1']:focus {
+    outline: none !important;
+}
+
 /* Global focus-visible for accessibility */
 :focus-visible {
     outline: 2px solid rgba(206, 35, 35, 0.8) !important;


### PR DESCRIPTION
💡 What: Added CSS rules for `[tabindex="-1"]:focus` to hide the default browser focus ring (`outline: none`) on globally targeted layout elements.
🎯 Why: When keyboard users activate the "Skip to content" link, focus transfers to `<main id="main" tabindex="-1">`. Without this rule, browsers (like Chrome) display a jarring full-page focus ring around the entire main layout container, rather than seamlessly transferring focus.
📸 Before/After: Before, a thick red outline surrounded the entire page's main content wrapper. Now, there is no outline when skipping, allowing normal element-by-element focus rings to resume cleanly on the next Tab press.
♿ Accessibility: Improves the visual keyboard navigation experience by hiding unnecessary layout focus indicators, making the site feel significantly more polished and less disruptive for keyboard users.

---
*PR created automatically by Jules for task [1799046211564580959](https://jules.google.com/task/1799046211564580959) started by @ryusoh*