### PR TITLE
Refactor: eliminate empty catch blocks for window.matchMedia

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,9 @@
 **Vulnerability:** Parsing arbitrarily large JSON payloads from untrusted client-side storage (`sessionStorage`) without length validation can lead to Denial of Service (DoS) attacks by exhausting memory and blocking the main thread execution during the `JSON.parse` operation.
 **Learning:** Functions that retrieve and deserialize stored values (like cursor positions) must implement bounds checking _before_ passing strings to expensive parsers. Even if the data is expected to be a small object, malicious actors can manipulate client storage.
 **Prevention:** Implement strict string length limits on all data read from `sessionStorage` or `localStorage` prior to parsing (e.g., `if (raw.length > 100) return null`) to mitigate memory exhaustion risks.
+
+## 2026-03-28 - [Empty Catch Blocks in prefersReducedMotion]
+
+**Vulnerability:** Empty catch blocks in `prefersReducedMotion` handlers across the codebase (`js/page-transition.js`, `js/ambient/ambient.js`, `js/block-navigation.js`) suppressed `window.matchMedia` errors. This silent failure hid potential issues in unsupported environments or testing contexts where `matchMedia` might throw.
+**Learning:** While gracefully falling back to `false` (meaning motion is enabled) is the correct functional behavior when `matchMedia` fails, the error itself must still be observable for debugging and health monitoring. A silent `catch {}` prevents this visibility.
+**Prevention:** Replace all empty catch blocks with defensive logging (e.g., `window.console.warn`). Always wrap the logging call in environmental safety checks (e.g., `typeof window !== 'undefined' && window.console`) to ensure the logging attempt itself does not cause a secondary fatal error.

--- a/js/ambient/ambient.js
+++ b/js/ambient/ambient.js
@@ -47,8 +47,15 @@
                     '(prefers-reduced-motion: reduce)'
                 );
             }
-        } catch {
-            // Ignore matchMedia errors
+        } catch (e) {
+            if (
+                typeof window !== 'undefined' &&
+                window !== null &&
+                window.console &&
+                typeof window.console.warn === 'function'
+            ) {
+                window.console.warn('[ambient] prefersReducedMotion error:', e);
+            }
         }
         const reduce = prefersReducedMotionMediaQuery
             ? prefersReducedMotionMediaQuery.matches

--- a/js/block-navigation.js
+++ b/js/block-navigation.js
@@ -65,7 +65,15 @@
                 );
             }
             return prefersReducedMotionMediaQuery ? prefersReducedMotionMediaQuery.matches : false;
-        } catch {
+        } catch (e) {
+            if (
+                typeof window !== 'undefined' &&
+                window !== null &&
+                window.console &&
+                typeof window.console.warn === 'function'
+            ) {
+                window.console.warn('[block-navigation] prefersReducedMotion error:', e);
+            }
             return false;
         }
     }

--- a/js/page-transition.js
+++ b/js/page-transition.js
@@ -39,7 +39,15 @@ import * as THREE from './vendor/three.module.min.js';
                 );
             }
             return prefersReducedMotionMediaQuery ? prefersReducedMotionMediaQuery.matches : false;
-        } catch {
+        } catch (e) {
+            if (
+                typeof window !== 'undefined' &&
+                window !== null &&
+                window.console &&
+                typeof window.console.warn === 'function'
+            ) {
+                window.console.warn('[page-transition] prefersReducedMotion error:', e);
+            }
             return false;
         }
     }
@@ -806,19 +814,39 @@ import * as THREE from './vendor/three.module.min.js';
         try {
             const parsedUrl = new window.URL(cleanUrl, window.location.href);
             if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
-                // eslint-disable-next-line no-console
-                console.error('[page-transition] Blocked potentially malicious URL scheme');
+                if (
+                    typeof window !== 'undefined' &&
+                    window !== null &&
+                    window.console &&
+                    typeof window.console.error === 'function'
+                ) {
+                    window.console.error(
+                        '[page-transition] Blocked potentially malicious URL scheme'
+                    );
+                }
                 return null;
             }
             if (parsedUrl.origin !== window.location.origin) {
-                // eslint-disable-next-line no-console
-                console.error('[page-transition] Blocked cross-origin navigation');
+                if (
+                    typeof window !== 'undefined' &&
+                    window !== null &&
+                    window.console &&
+                    typeof window.console.error === 'function'
+                ) {
+                    window.console.error('[page-transition] Blocked cross-origin navigation');
+                }
                 return null;
             }
             return cleanUrl;
         } catch (e) {
-            // eslint-disable-next-line no-console
-            console.error('[page-transition] Blocked invalid URL', e);
+            if (
+                typeof window !== 'undefined' &&
+                window !== null &&
+                window.console &&
+                typeof window.console.error === 'function'
+            ) {
+                window.console.error('[page-transition] Blocked invalid URL', e);
+            }
             return null;
         }
     }

--- a/tests/js/security.test.js
+++ b/tests/js/security.test.js
@@ -50,6 +50,11 @@ describe('DOM XSS Security Tests', () => {
         };
 
         const mockWindow = {
+            console: {
+                error: jest.fn(),
+                warn: jest.fn(),
+                log: jest.fn(),
+            },
             location: {
                 href: 'http://localhost/',
                 origin: 'http://localhost',
@@ -84,10 +89,6 @@ describe('DOM XSS Security Tests', () => {
             window: mockWindow,
             document: mockDocument,
             Promise: Promise,
-            console: {
-                error: jest.fn(),
-                log: jest.fn(),
-            },
             setTimeout: mockWindow.setTimeout,
             clearTimeout: mockWindow.clearTimeout,
             requestAnimationFrame: mockWindow.requestAnimationFrame,
@@ -120,7 +121,7 @@ describe('DOM XSS Security Tests', () => {
 
         pt.navigate('javascript:alert(1)');
         expect(context.window.location.assign).not.toHaveBeenCalled();
-        expect(context.console.error).toHaveBeenCalledWith(
+        expect(context.window.console.error).toHaveBeenCalledWith(
             expect.stringContaining('Blocked potentially malicious URL scheme')
         );
 
@@ -150,7 +151,7 @@ describe('DOM XSS Security Tests', () => {
 
         pt.navigate('http://example.com/login.html');
         expect(context.window.location.assign).not.toHaveBeenCalled();
-        expect(context.console.error).toHaveBeenCalledWith(
+        expect(context.window.console.error).toHaveBeenCalledWith(
             expect.stringContaining('Blocked cross-origin navigation')
         );
 
@@ -165,7 +166,7 @@ describe('DOM XSS Security Tests', () => {
         pt.navigate('  JAVASCRIPT:alert(1)');
 
         expect(context.window.location.assign).not.toHaveBeenCalled();
-        expect(context.console.error).toHaveBeenCalledWith(
+        expect(context.window.console.error).toHaveBeenCalledWith(
             expect.stringContaining('Blocked potentially malicious URL scheme')
         );
     });
@@ -177,7 +178,7 @@ describe('DOM XSS Security Tests', () => {
         pt.navigate('\x01\x02\x09\x1fjavascript:alert(1)');
 
         expect(context.window.location.assign).not.toHaveBeenCalled();
-        expect(context.console.error).toHaveBeenCalledWith(
+        expect(context.window.console.error).toHaveBeenCalledWith(
             expect.stringContaining('Blocked potentially malicious URL scheme')
         );
     });


### PR DESCRIPTION
This PR addresses the requirement to fix silent failures and eliminate empty catch blocks across the codebase as part of Module B: Resilience & Error Handling (The Sentinel).

**Changes Made:**
1.  **Refactored Empty Catch Blocks:** Replaced empty `catch {}` blocks around `window.matchMedia` calls in `js/page-transition.js`, `js/ambient/ambient.js`, and `js/block-navigation.js` with structured `catch (e) { ... }` blocks.
2.  **Defensive Logging:** Implemented defensive logging using `window.console.warn` ensuring robust checks (`typeof window !== 'undefined'`) prevent secondary throw errors.
3.  **Refactored `getValidatedUrl`:** Updated `getValidatedUrl` in `js/page-transition.js` to correctly log errors using the `window.console.error` pattern, rather than a raw `console.error` call.
4.  **Updated Tests:** Refactored Jest assertions in `tests/js/security.test.js` to mock and assert on `context.window.console.error` instead of `context.console.error`. All tests pass.
5.  **Updated Documentation:** Logged the learning concerning the empty catch blocks in `prefersReducedMotion` handlers to `.jules/sentinel.md`.

No external API signatures or structural changes breaking other parts of the system were made. All `pnpm lint` checks pass.

---
*PR created automatically by Jules for task [8111825353167886342](https://jules.google.com/task/8111825353167886342) started by @ryusoh*