### PR TITLE
🎨 Palette: [UX improvement] Add outline none to tabindex=-1 elements

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -488,6 +488,10 @@ footer {
     clip: auto;
 }
 
+[tabindex='-1']:focus {
+    outline: none !important;
+}
+
 /* Global focus-visible for accessibility */
 :focus-visible {
     outline: 2px solid rgba(206, 35, 35, 0.8) !important;

--- a/css/style.css
+++ b/css/style.css
@@ -1114,6 +1114,10 @@ td {
     clip: auto;
 }
 
+[tabindex='-1']:focus {
+    outline: none !important;
+}
+
 /* Global focus-visible for accessibility */
 :focus-visible {
     outline: 2px solid rgba(206, 35, 35, 0.8) !important;


### PR DESCRIPTION
What: Added `[tabindex="-1"]:focus { outline: none !important; }` to global CSS files `css/main_style.css` and `css/style.css`.
Why: Prevents default browser focus rings from appearing on layout containers (like `<main>`) when they receive programmatic focus, such as from 'Skip to content' links.
Before/After: Before, clicking a 'Skip to content' link would draw a large focus ring around the entire main content area on some browsers. After, the layout is visually unaffected while maintaining programmatic focus.
Accessibility: Improves visual polish without affecting keyboard navigation, as `tabindex="-1"` elements are excluded from the natural tab order. This ensures the focus transfer from skip links is visually seamless and less distracting.

---
*PR created automatically by Jules for task [2341626509141149763](https://jules.google.com/task/2341626509141149763) started by @ryusoh*