### PR TITLE
Palette: [Hide focus ring on skip link targets]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -27,3 +27,8 @@
 
 **Learning:** "Skip to content" links (with visually hidden `.sr-only` classes) are great for keyboard users, but if the target element (like `<main id="main">`) is not inherently focusable, some browsers will scroll the viewport but fail to move the actual focus. When the user presses Tab again, focus jumps back to the top of the page.
 **Action:** Always add `tabindex="-1"` to the target element of a skip link. This makes the element programmatically focusable without adding it to the normal tab order, ensuring focus is reliably transferred so the next Tab keypress moves into the main content.
+
+## 2026-11-22 - [Hide Focus Ring on Skip Link Targets]
+
+**Learning:** When using `tabindex="-1"` to make non-interactive layout elements programmatically focusable (like `<main>` for 'Skip to content' targets), browsers often apply a default focus ring. This ring is visually confusing as the element is not interactive.
+**Action:** Pair the `tabindex="-1"` attribute on layout targets with a global CSS rule like `[tabindex="-1"]:focus { outline: none !important; }` to prevent default focus rings, ensuring a clean visual experience while maintaining accessibility.

--- a/css/main_style.css
+++ b/css/main_style.css
@@ -496,6 +496,10 @@ footer {
     border-radius: 2px;
 }
 
+[tabindex='-1']:focus {
+    outline: none !important;
+}
+
 /* --- Mobile Banner --- */
 @media (min-width: 769px) {
     .mobile-banner {

--- a/css/style.css
+++ b/css/style.css
@@ -1122,6 +1122,10 @@ td {
     border-radius: 2px;
 }
 
+[tabindex='-1']:focus {
+    outline: none !important;
+}
+
 /* --- Scroll Reveal Instagram Icon --- */
 .scroll-reveal-instagram {
     display: block;


### PR DESCRIPTION
What: Add CSS rules to `[tabindex="-1"]:focus` to hide default browser focus rings on layout targets programmatically focused by skip links.
Why: Browsers often apply a default focus ring to elements like `<main tabindex="-1">` when targeted by "Skip to content" links, which is visually confusing for sighted keyboard users as the main element itself is not an interactive widget.
Before/After: Before, a visible outline appeared around the entire main content area after using the skip link. After, focus is transferred silently without visual disruption.
Accessibility: Improves visual clarity for keyboard navigation users by removing unnecessary focus indicators on non-interactive landmark layout elements, while preserving programmatically correct focus flow.

---
*PR created automatically by Jules for task [3247723096335954800](https://jules.google.com/task/3247723096335954800) started by @ryusoh*