### PR TITLE
Palette: [UX improvement] Improve skip link visibility and fix main content focus ring

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -480,12 +480,22 @@ footer {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-    position: static;
+    position: absolute;
     width: auto;
     height: auto;
     margin: 0;
     overflow: visible;
     clip: auto;
+    z-index: 9999;
+    background: #fff;
+    color: #000;
+    padding: 1em;
+    top: 0;
+    left: 0;
+}
+
+[tabindex='-1']:focus {
+    outline: none !important;
 }
 
 /* Global focus-visible for accessibility */

--- a/css/style.css
+++ b/css/style.css
@@ -1106,12 +1106,22 @@ td {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-    position: static;
+    position: absolute;
     width: auto;
     height: auto;
     margin: 0;
     overflow: visible;
     clip: auto;
+    z-index: 9999;
+    background: #fff;
+    color: #000;
+    padding: 1em;
+    top: 0;
+    left: 0;
+}
+
+[tabindex='-1']:focus {
+    outline: none !important;
 }
 
 /* Global focus-visible for accessibility */


### PR DESCRIPTION
💡 **What:** 
- Updated the `.sr-only-focusable:focus` and `:active` pseudo-classes to use `position: absolute`, high `z-index`, and distinct visual styling (black text on white background with padding).
- Added a global css rule `[tabindex="-1"]:focus` to force `outline: none !important`.

🎯 **Why:** 
Previously, the "Skip to content" link used `position: static` when focused, which could cause layout shifts in certain responsive viewports. More importantly, when the user pressed Enter on the "Skip to content" link to shift focus to the `<main tabindex="-1">` element, browsers applied their default native focus ring (e.g. a large blue box) around the entire page container, creating a visually distracting and unpolished experience.

📸 **Before/After:**
- **Before:** Tabbing to the first element showed raw text potentially shifting the header structure. Hitting enter drew a massive blue focus ring around the entire main layout section. 
- **After:** Tabbing reveals a clear, distinct button overlay at the top left. Hitting enter drops the focus onto the main container invisibly, allowing subsequent tabs to begin exactly at the first interactive project link.

♿ **Accessibility:**
Maintains full WCAG compliance for bypass blocks while drastically improving the visual clarity for keyboard-navigating sighted users without sacrificing the intended minimalist aesthetic.

---
*PR created automatically by Jules for task [12949284998969385491](https://jules.google.com/task/12949284998969385491) started by @ryusoh*