### PR TITLE
Sentinel: [test improvement] Add missing test coverage scenarios

### DIFF
--- a/js/loader/imageFallback.js
+++ b/js/loader/imageFallback.js
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 /* Simple <img> fallback: looks for data-fallbacks='["url1","url2",...]' */
 (function () {
     try {

--- a/tests/js/cursor-init.test.js
+++ b/tests/js/cursor-init.test.js
@@ -120,4 +120,16 @@ describe('js/cursor-init.js', () => {
 
         expect(customContext.window.cursorInstances).toBeUndefined();
     });
+
+    test('does not execute if document is not defined', () => {
+        const customCode = `
+            let document; // shadow the document
+            ${code}
+        `;
+
+        vm.createContext(context);
+        vm.runInContext(customCode, context);
+
+        expect(context.document.addEventListener).not.toHaveBeenCalled();
+    });
 });

--- a/tests/js/scroll-reveal-icon.test.js
+++ b/tests/js/scroll-reveal-icon.test.js
@@ -108,4 +108,17 @@ describe('scroll-reveal-icon.js', () => {
         vm.runInContext(sourceCode, context);
         expect(iconElement.classList.add).toHaveBeenCalledWith('is-visible');
     });
+
+    it('should not call requestAnimationFrame if ticking is true', () => {
+        // mock requestAnimationFrame to not call cb so ticking stays true
+        context.window.requestAnimationFrame = jest.fn();
+        vm.runInContext(sourceCode, context);
+
+        const onScroll = addEventListenerMock.mock.calls.find((call) => call[0] === 'scroll')[1];
+        onScroll();
+        expect(context.window.requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+        onScroll();
+        expect(context.window.requestAnimationFrame).toHaveBeenCalledTimes(1); // Still 1 because ticking is true
+    });
 });


### PR DESCRIPTION
This PR addresses the ultimate goal of reaching 100% test coverage by identifying and resolving three test coverage gaps.

What:
1.  **Removed coverage ignorance:** The `imageFallback.js` script was globally ignored by Istanbul. I removed `/* istanbul ignore file */` to accurately reflect its test coverage needs.
2.  **Added cursor-init coverage:** The `js/cursor-init.js` file checks for `typeof document !== 'undefined'` before executing. I added a test case in `tests/js/cursor-init.test.js` that shadows `document` to verify this early exit branch is correctly hit and doesn't crash the script.
3.  **Added scroll-reveal-icon coverage:** The `js/scroll-reveal-icon.js` script throttles the scroll listener using a `ticking` boolean flag and `requestAnimationFrame`. I added a test in `tests/js/scroll-reveal-icon.test.js` that verifies this throttling mechanism works. When `onScroll` is triggered twice before the animation frame executes, `requestAnimationFrame` should only be called once.

Why:
These changes directly increase test coverage and ensure critical edge cases (like server-side rendering or heavy scroll events) are properly evaluated by our test runner.

Accessibility/UX:
N/A - purely backend/testing improvements without changing production code logic or rendering.

---
*PR created automatically by Jules for task [15742662301948599644](https://jules.google.com/task/15742662301948599644) started by @ryusoh*