### PR TITLE
TestPilot: [testing] Add coverage for specific early exit edge cases

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -21,3 +21,11 @@
 ## 2025-03-21 - Extracting nested unexported functions in IIFEs
 
 **Learning:** When extracting an internal function from an IIFE for isolated testing in a vm context, use a non-greedy multiline regex (e.g., `code.match(/function myFunc\(\) {[\s\S]*?}/)[0]`) to reliably extract its exact source string, rather than complex `.replace()` chains that mangle closure scopes.
+
+## 2024-05-18 - Defensive Missing Global Fallback
+
+**Learning:** When asserting behavior in Edge Cases for utilities expecting globals (e.g. `window.console` during failure states), one must test both if `window.console` is missing entirely and if specific properties (e.g. `window.console.warn`) are missing, to ensure defensive coding doesn't inadvertently mask failures by crashing.
+
+## 2024-05-18 - Testing Early Exit and Rate Limit Conditions
+
+**Learning:** When checking logic that includes rate limits, boundaries, or early exits to avoid re-running calculations (e.g., bypassing fallback logic in `font-awesome-loader` if `this.fontAwesomeLoaded` is already true, or early exiting in `page-transition.js` if the payload exceeds 5MB), verify that these explicit conditions prevent internal API calls like `sessionStorage.setItem` or `stopChecking` using `.not.toHaveBeenCalled()`.

--- a/tests/js/font-awesome-loader.test.js
+++ b/tests/js/font-awesome-loader.test.js
@@ -387,5 +387,23 @@ describe('FontAwesomeLoader', () => {
             expect(loader.showIcons).toHaveBeenCalled();
             expect(loader.stopChecking).toHaveBeenCalled();
         });
+
+        test('should do nothing if fontAwesomeLoaded is true when CSS onload fires', () => {
+            const mockLink1 = { href: 'https://example.com/font-awesome.css', onload: null };
+            context.document.querySelectorAll.mockReturnValue([mockLink1]);
+
+            loader.waitForFontLoad();
+            context.__timeoutCb();
+
+            // Set it to true before the onload callback executes (simulating the interval check already finding it)
+            loader.fontAwesomeLoaded = true;
+            loader.stopChecking = jest.fn();
+
+            mockLink1.onload();
+
+            // Should not call showIcons or stopChecking again
+            expect(loader.showIcons).not.toHaveBeenCalled();
+            expect(loader.stopChecking).not.toHaveBeenCalled();
+        });
     });
 });

--- a/tests/js/page-transition.test.js
+++ b/tests/js/page-transition.test.js
@@ -495,6 +495,16 @@ describe('page-transition.js', () => {
             );
         });
 
+        test('should catch and log error if dataUrl payload exceeds 5MB limit', () => {
+            context.window.sessionStorage.setItem.mockClear();
+
+            // Generate a string larger than 5242880 characters
+            const largeString = 'a'.repeat(5242881);
+            storeCaptureData(largeString);
+
+            expect(context.window.sessionStorage.setItem).not.toHaveBeenCalled();
+        });
+
         test('should return early if dataUrl is falsy', () => {
             context.window.sessionStorage.setItem.mockClear();
             storeCaptureData(null);

--- a/tests/js/service-worker-register.test.js
+++ b/tests/js/service-worker-register.test.js
@@ -87,6 +87,22 @@ describe('service-worker-register', () => {
         expect(context.navigator.serviceWorker.register).toHaveBeenCalledWith('/sw.js');
     });
 
+    test('gracefully handles missing window.console.warn when hostname parsing fails', () => {
+        Object.defineProperty(context.window.location, 'hostname', {
+            get: () => {
+                throw new Error('SecurityError');
+            },
+        });
+        context.window.console = {}; // no warn
+
+        expect(() => {
+            vm.createContext(context);
+            vm.runInContext(code, context);
+        }).not.toThrow();
+
+        expect(context.navigator.serviceWorker.register).toHaveBeenCalledWith('/sw.js');
+    });
+
     test('bails out if window is undefined', () => {
         delete context.window;
         vm.createContext(context);


### PR DESCRIPTION
**What:**
Added unit tests to three specific utility files to cover missing early-exit or exception fallback edge cases that are not triggered by the standard happy path.

**Why:**
To ensure system boundaries function as expected when hitting extremes (storage limits, timing constraints, environment restrictions), adhering to the TestPilot mandate of high confidence and complete test coverage over core functionality.

**Before/After:**
- *Before:* Edge cases regarding storage size constraints in `page-transition`, fast-loading CSS states in `font-awesome-loader`, and aggressive console mocking in `service-worker-register` lacked verified assertions.
- *After:* All three conditions are now explicitly verified in Jest, guaranteeing early returns and robust handling.

**Accessibility:**
N/A (Testing changes only)

---
*PR created automatically by Jules for task [15817956343856671082](https://jules.google.com/task/15817956343856671082) started by @ryusoh*