### PR TITLE
Architect: Refactor to reduce cyclomatic complexity in ambient and image fallback logic

### DIFF
--- a/js/ambient/ambient.js
+++ b/js/ambient/ambient.js
@@ -88,24 +88,29 @@
         if (shouldSkip(C, force)) {
             return;
         }
-        const s = window.Sketch.create({
-            container: document.body,
-            retina: true,
-            interval: 2,
-            globals: false,
-            autopause: true,
-        });
-        s.canvas.className += ' ambient-canvas';
-        s.canvas.style.position = 'fixed';
-        s.canvas.style.top = '0';
-        s.canvas.style.left = '0';
-        s.canvas.style.pointerEvents = 'none';
-        s.canvas.style.zIndex = String(C.zIndex);
-        s.canvas.style.width = '100vw';
-        s.canvas.style.height = '100vh';
-        if (trace) {
-            s.canvas.style.background = 'rgba(255,0,0,0.06)';
+        function initSketchCanvas(C, trace) {
+            const sketchInstance = window.Sketch.create({
+                container: document.body,
+                retina: true,
+                interval: 2,
+                globals: false,
+                autopause: true,
+            });
+            sketchInstance.canvas.className += ' ambient-canvas';
+            sketchInstance.canvas.style.position = 'fixed';
+            sketchInstance.canvas.style.top = '0';
+            sketchInstance.canvas.style.left = '0';
+            sketchInstance.canvas.style.pointerEvents = 'none';
+            sketchInstance.canvas.style.zIndex = String(C.zIndex);
+            sketchInstance.canvas.style.width = '100vw';
+            sketchInstance.canvas.style.height = '100vh';
+            if (trace) {
+                sketchInstance.canvas.style.background = 'rgba(255,0,0,0.06)';
+            }
+            return sketchInstance;
         }
+
+        const s = initSketchCanvas(C, trace);
         function metrics() {
             const ratio = window.devicePixelRatio || 1;
             const cw = s.canvas && s.canvas.clientWidth ? s.canvas.clientWidth : window.innerWidth;

--- a/js/loader/imageFallback.js
+++ b/js/loader/imageFallback.js
@@ -1,56 +1,62 @@
 /* Simple <img> fallback: looks for data-fallbacks='["url1","url2",...]' */
 (function () {
     try {
-        function attach(el) {
+        function parseFallbacks(el) {
             const listAttr = el.getAttribute('data-fallbacks');
             if (!listAttr || listAttr.length > 1024) {
-                return;
+                return null;
             }
-            let list;
+
             try {
-                list = JSON.parse(listAttr);
+                const list = JSON.parse(listAttr);
+                if (!Array.isArray(list) || list.length === 0) {
+                    return null;
+                }
+
+                const sanitizedList = [];
+                for (let k = 0; k < list.length; k++) {
+                    if (typeof list[k] === 'string') {
+                        sanitizedList.push(list[k]);
+                    }
+                }
+                return sanitizedList.length > 0 ? sanitizedList : null;
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.warn('Caught exception:', error);
-                list = [];
+                return null;
             }
-            if (!Array.isArray(list) || list.length === 0) {
-                return;
-            }
+        }
 
-            // Return a sanitized, fresh array containing only validated string properties
-            const sanitizedList = [];
-            for (let k = 0; k < list.length; k++) {
-                if (typeof list[k] === 'string') {
-                    sanitizedList.push(list[k]);
-                }
-            }
-            list = sanitizedList;
-            if (list.length === 0) {
-                return;
-            }
-
+        function setupFallback(el, list) {
             el.classList.remove('is-fallback-ready');
             let i = 0;
+
             function tryNext() {
-                if (i >= list.length) {
-                    return;
+                if (i < list.length) {
+                    el.src = list[i++];
                 }
-                el.src = list[i++];
             }
+
             el.addEventListener('load', function onLoad() {
                 el.classList.add('is-fallback-ready');
             });
-            el.addEventListener('error', function () {
-                tryNext();
-            });
-            // If current src fails, onerror will advance; ensure first URL is current
+
+            el.addEventListener('error', tryNext);
+
             if (!el.src || el.src !== list[0]) {
                 el.src = list[0];
             } else if (el.complete && el.naturalWidth > 0) {
                 el.classList.add('is-fallback-ready');
             }
         }
+
+        function attach(el) {
+            const list = parseFallbacks(el);
+            if (list) {
+                setupFallback(el, list);
+            }
+        }
+
         const imgs = document.querySelectorAll('img[data-fallbacks]');
         for (let j = 0; j < imgs.length; j++) {
             attach(imgs[j]);


### PR DESCRIPTION
Extracted setup code to reduce function cyclomatic complexity to meet architectural requirements.
* Extract `Sketch` canvas initialization into `initSketchCanvas` in `js/ambient/ambient.js`.
* Extract fallback logic into `parseFallbacks` and `setupFallback` in `js/loader/imageFallback.js`.

These refactors reduce complexity without introducing behavioral regressions. Tests and linters pass cleanly.

---
*PR created automatically by Jules for task [5100492333515794088](https://jules.google.com/task/5100492333515794088) started by @ryusoh*