### PR TITLE
Add tests for missing coverage cases

### DIFF
--- a/tests/js/ambient/config/default.test.js
+++ b/tests/js/ambient/config/default.test.js
@@ -98,4 +98,20 @@ describe('ambient/config/default.js', () => {
             vm.runInContext(code, context);
         }).not.toThrow();
     });
+
+    test('gracefully handles completely missing window.console without throwing', () => {
+        context.window = {}; // Missing console entirely
+
+        // Use a Proxy or defineProperty to throw when AMBIENT_CONFIG is accessed/set
+        Object.defineProperty(context.window, 'AMBIENT_CONFIG', {
+            get: () => {
+                throw new Error('Simulated config error');
+            },
+        });
+
+        expect(() => {
+            vm.createContext(context);
+            vm.runInContext(code, context);
+        }).not.toThrow();
+    });
 });

--- a/tests/js/cursor-init.test.js
+++ b/tests/js/cursor-init.test.js
@@ -91,6 +91,18 @@ describe('js/cursor-init.js', () => {
         }).not.toThrow();
     });
 
+    test('does not execute if window.gsap is missing and document exists', () => {
+        delete context.window.gsap;
+
+        vm.createContext(context);
+        vm.runInContext(code, context);
+
+        // Trigger DOMContentLoaded
+        context.__domContentLoadedCb();
+
+        expect(mockInitCursor).not.toHaveBeenCalled();
+    });
+
     test('does not throw when initCursor throws but allows bubbling', () => {
         context.window.gsap = {}; // Mock GSAP
 

--- a/tests/js/loader/vendorLoader.test.js
+++ b/tests/js/loader/vendorLoader.test.js
@@ -114,4 +114,19 @@ describe('loader/vendorLoader.js', () => {
             vm.runInContext(code, context);
         }).not.toThrow();
     });
+
+    test('gracefully handles completely missing window.console without throwing', () => {
+        context.window = {}; // Missing console completely
+
+        Object.defineProperty(context.window, 'CDNLoader', {
+            get: () => {
+                throw new Error('Simulated config error');
+            },
+        });
+
+        expect(() => {
+            vm.createContext(context);
+            vm.runInContext(code, context);
+        }).not.toThrow();
+    });
 });


### PR DESCRIPTION
Adds test coverage for three edge cases where error handling logic lacked explicit tests for completely missing global objects.

---
*PR created automatically by Jules for task [3331072910130876774](https://jules.google.com/task/3331072910130876774) started by @ryusoh*