### PR TITLE
Palette: [UX improvement] Enable viewport zooming

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         />
         <meta
             name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1, user-scalable=no, minimal-ui"
+            content="width=device-width, initial-scale=1.0, minimal-ui"
         />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />


### PR DESCRIPTION
**💡 What:** Removed `user-scalable=no`, `maximum-scale=1.0`, and `minimum-scale=1` from the viewport meta tag in `index.html`.

**🎯 Why:** Hard-coded zoom restrictions via viewport meta tags prevent users from utilizing their browser's native pinch-to-zoom capabilities. This is a severe accessibility anti-pattern, particularly for users with low vision who need to magnify text or images. Restoring this functionality adheres to WCAG best practices and significantly improves the mobile user experience.

**📸 Before/After:** (No visual change on desktop, but zooming is now enabled on mobile devices).

**♿ Accessibility:** Resolved a critical accessibility issue (WCAG 1.4.4 Resize text) by allowing users to scale the content natively on touch devices.

---
*PR created automatically by Jules for task [15646947057152102289](https://jules.google.com/task/15646947057152102289) started by @ryusoh*