### PR TITLE
Palette: [UX improvement] Add keyboard shortcut hint to back button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -210,6 +210,20 @@ a.nav-back:focus {
     color: #ce2323;
     opacity: 1;
 }
+a.nav-back .kbd-hint {
+    font-family: monospace;
+    font-size: 0.6em;
+    margin-left: 8px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    vertical-align: middle;
+    letter-spacing: 1px;
+}
+a.nav-back:hover .kbd-hint,
+a.nav-back:focus .kbd-hint {
+    opacity: 1;
+}
+
 nav {
     position: fixed;
     top: 0;

--- a/p1/index.html
+++ b/p1/index.html
@@ -127,6 +127,7 @@
             <!-- prettier-ignore -->
             <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
                 <i class="fa fa-chevron-left" aria-hidden="true"></i>
+                <span class="kbd-hint" aria-hidden="true">ESC</span>
             </a>
 
             <!-- Page Header -->

--- a/p2/index.html
+++ b/p2/index.html
@@ -127,6 +127,7 @@
             <!-- prettier-ignore -->
             <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
                 <i class="fa fa-chevron-left" aria-hidden="true"></i>
+                <span class="kbd-hint" aria-hidden="true">ESC</span>
             </a>
 
             <!-- Page Header -->

--- a/p3/index.html
+++ b/p3/index.html
@@ -122,6 +122,8 @@
             <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition
             data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
+                <span class="kbd-hint" aria-hidden="true">ESC</span>
+
         </a>
 
             <!-- Page Header -->

--- a/p4/index.html
+++ b/p4/index.html
@@ -122,6 +122,8 @@
             <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition
             data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
+                <span class="kbd-hint" aria-hidden="true">ESC</span>
+
         </a>
 
             <!-- Page Header -->


### PR DESCRIPTION
💡 What: Added a keyboard shortcut hint (`ESC`) to the `.nav-back` button on all project pages (`p1`, `p2`, `p3`, `p4`).
🎯 Why: Sighted users are not naturally aware that pressing the Escape key navigates them back from the project galleries, as there was no visible indicator for the shortcut (`aria-keyshortcuts` is only for screen readers).
📸 Before/After: Before, only a `<` chevron was visible. Now, hovering or focusing on the chevron reveals a small `ESC` hint next to it.
♿ Accessibility: Improves usability for sighted keyboard users by visually exposing existing keyboard shortcuts without violating the site's strict minimalist aesthetic.

---
*PR created automatically by Jules for task [8896328864132416264](https://jules.google.com/task/8896328864132416264) started by @ryusoh*