### PR TITLE
Bolt: Defer asset preloading using requestIdleCallback

### DIFF
--- a/js/preloader.js
+++ b/js/preloader.js
@@ -174,7 +174,17 @@ class AssetPreloader {
         if ('serviceWorker' in navigator) {
             // Wait for content to load, then preload other page assets
             window.addEventListener('load', () => {
-                this.preloadForCurrentPage();
+                /**
+                 * Bolt Optimization:
+                 * - What: Defer asset preloading using `requestIdleCallback`.
+                 * - Why: Preloading assets immediately on `load` can block the main thread and compete with other post-load tasks (like rendering the page or hydrating).
+                 * - Impact: Improves Time to Interactive (TTI) by shifting low-priority preloading work to browser idle periods.
+                 */
+                if (window.requestIdleCallback) {
+                    window.requestIdleCallback(() => this.preloadForCurrentPage());
+                } else {
+                    setTimeout(() => this.preloadForCurrentPage(), 1);
+                }
             });
         }
     }

--- a/tests/js/preloader.test.js
+++ b/tests/js/preloader.test.js
@@ -45,11 +45,13 @@ describe('AssetPreloader', () => {
                 pathname: '/',
             },
             addEventListener: jest.fn(),
+            requestIdleCallback: jest.fn((cb) => cb()),
         };
 
         context = {
             document: mockDocument,
             window: mockWindow,
+            setTimeout: jest.fn((cb) => cb()),
             navigator: {
                 serviceWorker: {},
             },


### PR DESCRIPTION
What: Wrapped the `preloadForCurrentPage` asset preloading logic inside `window.requestIdleCallback` (with a `setTimeout` fallback for unsupported browsers) during the `window.load` event in `js/preloader.js`.

Why: Preloading image assets immediately and synchronously on the `load` event blocks the main thread. This competes with critical post-load tasks like parsing JavaScript, rendering final styles, or initializing interactive elements.

Impact: Improves Time to Interactive (TTI) and reduces main-thread blocking time immediately after the page load by shifting the low-priority work of creating and appending DOM elements to the browser's idle periods.

Measurement: Can be verified by running a Lighthouse performance profile and observing a reduction in main-thread blocking time during the critical post-load initialization phase. Tests successfully updated and verified.

---
*PR created automatically by Jules for task [13083666119209584495](https://jules.google.com/task/13083666119209584495) started by @ryusoh*