### PR TITLE
Palette: [Accessibility enhancement for external links]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -36,4 +36,4 @@
 ## 2026-11-23 - [UX/Accessibility: target="_blank" and mailto: links]
 
 **Learning:** Opening a new tab merely to trigger an email client is an unnecessary friction point and a known anti-pattern. Applying `target="_blank"` to `mailto:` links spawns a confusing blank tab that users must manually close. Furthermore, external links lacking an explicit indication that they open in a new tab can disorient screen reader users due to sudden context switching.
-**Action:** Always avoid applying `target="_blank"` to `mailto:` links. For any external links that correctly open in a new tab using `target="_blank"`, strictly append ` (opens in a new tab)` to their `aria-label` to ensure predictability for screen reader users.
+**Action:** Always avoid applying `target="_blank"` to `mailto:` links. For any external links that correctly open in a new tab using `target="_blank"`, strictly append `(opens in a new tab)` to their `aria-label` to ensure predictability for screen reader users.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,8 @@
 
 **Learning:** When using `tabindex="-1"` to make non-interactive layout elements programmatically focusable (like `<main>` for 'Skip to content' targets), browsers often apply a default focus ring. This ring is visually confusing as the element is not interactive.
 **Action:** Pair the `tabindex="-1"` attribute on layout targets with a global CSS rule like `[tabindex="-1"]:focus { outline: none !important; }` to prevent default focus rings, ensuring a clean visual experience while maintaining accessibility.
+
+## 2026-11-23 - [UX/Accessibility: target="_blank" and mailto: links]
+
+**Learning:** Opening a new tab merely to trigger an email client is an unnecessary friction point and a known anti-pattern. Applying `target="_blank"` to `mailto:` links spawns a confusing blank tab that users must manually close. Furthermore, external links lacking an explicit indication that they open in a new tab can disorient screen reader users due to sudden context switching.
+**Action:** Always avoid applying `target="_blank"` to `mailto:` links. For any external links that correctly open in a new tab using `target="_blank"`, strictly append ` (opens in a new tab)` to their `aria-label` to ensure predictability for screen reader users.

--- a/index.html
+++ b/index.html
@@ -83,22 +83,21 @@
                     <span class="social-icons-container">
                         <!-- prettier-ignore -->
                         <a href="https://instagram.com/lyeutsaon" target="_blank" rel="noopener noreferrer"
-                        aria-label="Instagram Lyeutsaon">
+                        aria-label="Instagram Lyeutsaon (opens in a new tab)">
                         <i class="fa fa-instagram social-icon" aria-hidden="true"></i>
                     </a>
                         <!-- prettier-ignore -->
                         <a href="https://instagram.com/lyeutsaon.misc" target="_blank" rel="noopener noreferrer"
-                        aria-label="Instagram Lyeutsaon Misc">
+                        aria-label="Instagram Lyeutsaon Misc (opens in a new tab)">
                         <i class="fa fa-instagram social-icon" aria-hidden="true"></i>
                     </a>
                         <!-- prettier-ignore -->
-                        <a href="mailto:info@lyeutsaon.com" target="_blank" rel="noopener noreferrer"
-                        aria-label="Email Info">
+                        <a href="mailto:info@lyeutsaon.com" aria-label="Email Info">
                         <i class="fa fa-envelope-o social-icon" aria-hidden="true"></i>
                     </a>
                         <!-- prettier-ignore -->
                         <a href="https://www.linkedin.com/in/zhuangliudev/" target="_blank" rel="noopener noreferrer"
-                        aria-label="LinkedIn Profile">
+                        aria-label="LinkedIn Profile (opens in a new tab)">
                         <i class="fa fa-linkedin-square social-icon" aria-hidden="true"></i>
                     </a>
                     </span>
@@ -154,7 +153,7 @@
         />
         <footer>
             <!-- prettier-ignore -->
-            <a href="https://github.com/ryusoh" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile"><i
+            <a href="https://github.com/ryusoh" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile (opens in a new tab)"><i
                 class="fa fa-github" aria-hidden="true"></i></a>
         </footer>
 

--- a/p1/index.html
+++ b/p1/index.html
@@ -270,7 +270,7 @@
                         target="_blank"
                         rel="noopener noreferrer"
                         class="scroll-reveal-instagram"
-                        aria-label="Instagram Lyeutsaon"
+                        aria-label="Instagram Lyeutsaon (opens in a new tab)"
                     >
                         <i class="fa fa-instagram" aria-hidden="true"></i>
                     </a>

--- a/p2/index.html
+++ b/p2/index.html
@@ -276,7 +276,7 @@
                         target="_blank"
                         rel="noopener noreferrer"
                         class="scroll-reveal-instagram"
-                        aria-label="Instagram Lyeutsaon"
+                        aria-label="Instagram Lyeutsaon (opens in a new tab)"
                     >
                         <i class="fa fa-instagram" aria-hidden="true"></i>
                     </a>

--- a/p3/index.html
+++ b/p3/index.html
@@ -270,7 +270,7 @@
                         target="_blank"
                         rel="noopener noreferrer"
                         class="scroll-reveal-instagram"
-                        aria-label="Instagram Lyeutsaon"
+                        aria-label="Instagram Lyeutsaon (opens in a new tab)"
                     >
                         <i class="fa fa-instagram" aria-hidden="true"></i>
                     </a>

--- a/p4/index.html
+++ b/p4/index.html
@@ -273,7 +273,7 @@
                         target="_blank"
                         rel="noopener noreferrer"
                         class="scroll-reveal-instagram"
-                        aria-label="Instagram Lyeutsaon"
+                        aria-label="Instagram Lyeutsaon (opens in a new tab)"
                     >
                         <i class="fa fa-instagram" aria-hidden="true"></i>
                     </a>


### PR DESCRIPTION
💡 **What**:
- Removed `target="_blank"` and `rel="noopener noreferrer"` from the `mailto:` link on the homepage.
- Appended ` (opens in a new tab)` to the `aria-label` of external links (Instagram, LinkedIn, GitHub) across the homepage and project pages (`p1` to `p4`).
- Documented this learning in `.jules/palette.md`.

🎯 **Why**:
- Spawning a blank tab merely to open an email client (`mailto:`) creates friction and confusion for users, violating good UX patterns.
- Opening external links in a new tab without explicit warning disorients screen reader users. Adding this text provides necessary context.

📸 **Before/After**:
- Before: `<a href="mailto:..." target="_blank">`
- After: `<a href="mailto:...">`
- Before: `aria-label="Instagram Lyeutsaon"`
- After: `aria-label="Instagram Lyeutsaon (opens in a new tab)"`

♿ **Accessibility**:
- This change provides explicit warning to screen reader users about context switches caused by external links, aligning with WCAG 2.1 Success Criterion 3.2.2 Predictable (On Input).

---
*PR created automatically by Jules for task [15849316161454614896](https://jules.google.com/task/15849316161454614896) started by @ryusoh*