### PR TITLE
TestPilot: Add fallback edge case unit tests

### DIFF
--- a/tests/js/ambient/loader.test.js
+++ b/tests/js/ambient/loader.test.js
@@ -182,4 +182,32 @@ describe('ambient/loader.js', () => {
             expect.any(Error)
         );
     });
+
+    test('gracefully handles missing window.console.warn during async rejection', async () => {
+        delete context.window.console;
+        mockCDNLoader.loadCssWithFallback.mockRejectedValue(new Error('Simulated network error'));
+
+        vm.createContext(context);
+
+        expect(() => {
+            vm.runInContext(code, context);
+        }).not.toThrow();
+
+        await new Promise(process.nextTick);
+        await new Promise(process.nextTick);
+    });
+
+    test('gracefully handles missing window.console during sync error', () => {
+        delete context.window.console;
+        Object.defineProperty(context.window, 'matchMedia', {
+            get: () => {
+                throw new Error('Simulated synchronous error');
+            },
+        });
+
+        vm.createContext(context);
+        expect(() => {
+            vm.runInContext(code, context);
+        }).not.toThrow();
+    });
 });

--- a/tests/js/loader/cdnFallback.test.js
+++ b/tests/js/loader/cdnFallback.test.js
@@ -248,6 +248,41 @@ describe('CDNLoader', () => {
         });
     });
 
+    describe('fallback edge cases', () => {
+        it('should gracefully handle missing window.console.warn', async () => {
+            const urls = ['style.css'];
+            context.fetch.mockRejectedValueOnce(new Error('Network Error'));
+
+            // Remove warn from console
+            delete context.window.console;
+
+            const promise = loader.loadCssWithFallback(urls);
+            const linkEl = createdElements.find((el) => el.tagName === 'link');
+            linkEl.onerror();
+
+            await expect(promise).resolves.toBeUndefined();
+        });
+
+        it('should call window.console.warn when fetch fails after link tag fails', async () => {
+            context.window.console = {
+                warn: jest.fn(),
+            };
+            const urls = ['style.css'];
+            const mockError = new Error('Network Error');
+            context.fetch.mockRejectedValueOnce(mockError);
+
+            const promise = loader.loadCssWithFallback(urls);
+            const linkEl = createdElements.find((el) => el.tagName === 'link');
+            linkEl.onerror();
+
+            await expect(promise).resolves.toBeUndefined();
+            expect(context.window.console.warn).toHaveBeenCalledWith(
+                'CDN fallback CSS load failed:',
+                mockError
+            );
+        });
+    });
+
     describe('empty urls edge case for loadScriptSequential', () => {
         it('should reject if urls is empty', async () => {
             const { loadScriptSequential } = context.window.CDNLoader;

--- a/tests/js/loader/imageFallback.test.js
+++ b/tests/js/loader/imageFallback.test.js
@@ -172,4 +172,24 @@ describe('imageFallback.js', () => {
         errorListener({ target: imgElement }); // Stop at url3
         expect(imgElement.src).toBe('url3');
     });
+
+    it('should handle exception when window.console.warn is missing', () => {
+        imgElement.getAttribute.mockReturnValue('invalid-json');
+        delete context.window.console;
+
+        expect(() => {
+            vm.runInContext(sourceCode, context);
+        }).not.toThrow();
+    });
+
+    it('should handle general exception when window.console.warn is missing', () => {
+        context.document.querySelectorAll = jest.fn(() => {
+            throw new Error('Test general exception');
+        });
+        delete context.window.console;
+
+        expect(() => {
+            vm.runInContext(sourceCode, context);
+        }).not.toThrow();
+    });
 });


### PR DESCRIPTION
Identified 3 areas of missing branch coverage in the loader fallback utilities and added robust unit tests ensuring the modules fail gracefully when standard globals like `window.console` are stripped from the environment.

---
*PR created automatically by Jules for task [3433694675921344894](https://jules.google.com/task/3433694675921344894) started by @ryusoh*