### PR TITLE
Palette: Allow native pinch-to-zoom for better accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2024-04-15 - [Accessibility: Viewport Pinch-to-Zoom Restriction]
+
+**Learning:** Using `user-scalable=no`, `maximum-scale=1.0`, or `minimum-scale=1` in the viewport `<meta>` tag is a major accessibility anti-pattern. It prevents users, particularly those with low vision, from utilizing native browser pinch-to-zoom capabilities, which is a direct violation of WCAG best practices for responsive web design.
+**Action:** Always verify that viewport `<meta>` tags strictly omit scale-restricting properties. Ensure the standard `width=device-width, initial-scale=1` format is used to allow unrestricted native zooming.

--- a/index.html
+++ b/index.html
@@ -27,10 +27,7 @@
             http-equiv="Content-Security-Policy"
             content="default-src 'self'; script-src 'self' https://www.google-analytics.com https://static.cloudflareinsights.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com https://fonts.bunny.net https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://fonts.bunny.net https://cdnjs.cloudflare.com; img-src 'self' data: https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1, user-scalable=no, minimal-ui"
-        />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
💡 What: Removed scale-restricting properties (`user-scalable=no`, `maximum-scale=1.0`, `minimum-scale=1`) from the viewport `<meta>` tag in `index.html`.
🎯 Why: Restricting zoom on mobile devices is a major accessibility anti-pattern. Allowing native pinch-to-zoom ensures the site is accessible to users with low vision who rely on magnification to read content.
♿ Accessibility: Improves compliance with WCAG guidelines for scalable text and responsive web design.

---
*PR created automatically by Jules for task [9314064030269269304](https://jules.google.com/task/9314064030269269304) started by @ryusoh*