### PR TITLE
🛡️ Sentinel: Add timeout to fetch requests to prevent DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,9 @@
 **Vulnerability:** `URLSearchParams` was parsing `window.location.search` without any length limitations. An attacker could craft a massive query string, potentially causing performance degradation or memory exhaustion on the client-side.
 **Learning:** Just as with `localStorage` parsing, any input derived from the environment—including URL parameters—should be length-validated before being handed off to native parsers, serving as a defense-in-depth measure.
 **Prevention:** Apply a reasonable bounds check (e.g., 1000 characters) to `window.location.search` before invoking `URLSearchParams`.
+
+## 2024-04-16 - [DoS via Hanging Fetch Requests]
+
+**Vulnerability:** External `fetch` requests in `cdnFallback.js` lacked explicit timeouts. This could lead to client-side Denial of Service (DoS) and resource exhaustion if the remote server hung indefinitely, blocking the completion of the fallback CSS loading promise.
+**Learning:** By default, the native `fetch` API does not implement a timeout. In environments where network reliability is uncertain, failing to bound the duration of network requests leaves the application vulnerable to stalled execution paths.
+**Prevention:** Always wrap external `window.fetch` requests with an explicit timeout mechanism using `AbortController` and `setTimeout` (e.g., 5000ms), and ensure the timeout is cleaned up to prevent memory leaks.

--- a/js/loader/cdnFallback.js
+++ b/js/loader/cdnFallback.js
@@ -52,7 +52,18 @@
                     if (!last) {
                         return resolve();
                     }
-                    fetch(last, { mode: 'cors' })
+                    let controller;
+                    let timeoutId;
+                    const options = { mode: 'cors' };
+                    if (typeof window !== 'undefined' && window.AbortController) {
+                        controller = new window.AbortController();
+                        options.signal = controller.signal;
+                        timeoutId = setTimeout(function () {
+                            controller.abort();
+                        }, 5000);
+                    }
+
+                    fetch(last, options)
                         .then(function (r) {
                             return r.ok ? r.text() : Promise.reject();
                         })
@@ -72,6 +83,11 @@
                                 window.console.warn('CDN fallback CSS load failed:', e);
                             }
                             resolve();
+                        })
+                        .finally(function () {
+                            if (timeoutId) {
+                                clearTimeout(timeoutId);
+                            }
                         });
                     return;
                 }

--- a/tests/js/loader/cdnFallback.test.js
+++ b/tests/js/loader/cdnFallback.test.js
@@ -169,7 +169,10 @@ describe('CDNLoader', () => {
             linkEl.onerror();
 
             await promise;
-            expect(window.fetch).toHaveBeenCalledWith('style.css', expect.objectContaining({ mode: 'cors' }));
+            expect(window.fetch).toHaveBeenCalledWith(
+                'style.css',
+                expect.objectContaining({ mode: 'cors' })
+            );
             const styleTag = createdElements.find((el) => el.tagName === 'STYLE');
             expect(styleTag.textContent).toBe('body { color: red; }');
         });

--- a/tests/js/loader/cdnFallback.test.js
+++ b/tests/js/loader/cdnFallback.test.js
@@ -169,7 +169,7 @@ describe('CDNLoader', () => {
             linkEl.onerror();
 
             await promise;
-            expect(window.fetch).toHaveBeenCalledWith('style.css', { mode: 'cors' });
+            expect(window.fetch).toHaveBeenCalledWith('style.css', expect.objectContaining({ mode: 'cors' }));
             const styleTag = createdElements.find((el) => el.tagName === 'STYLE');
             expect(styleTag.textContent).toBe('body { color: red; }');
         });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External `window.fetch` requests in `js/loader/cdnFallback.js` did not have explicit timeouts. This could lead to hanging requests, blocking promises from resolving, and causing client-side memory exhaustion or DoS.
🎯 Impact: Could cause the client to hang if a requested CDN resource was unresponsive.
🔧 Fix: Wrapped the `fetch` request with an `AbortController` and a `setTimeout` of 5000ms. Cleaned up the timeout using `.finally()`. Gracefully falls back to standard fetch in older environments without `AbortController`.
✅ Verification: Tests updated to pass `signal` parameter, and Playwright verification successful locally.

---
*PR created automatically by Jules for task [17263443067856349890](https://jules.google.com/task/17263443067856349890) started by @ryusoh*