### PR TITLE
Bolt: Replace gsap.to() with gsap.quickTo() in magnetic-nav.js

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -80,3 +80,9 @@
 **Learning:** Using `gsap.to()` directly inside high-frequency event listeners like `mousemove` instantiates a new tween object on every frame/event. This results in significant memory churn, garbage collection overhead, and main-thread jank, especially for continuous interactions like mouse parallax.
 
 **Action:** When tracking high-frequency events (like mouse position) with GSAP, pre-initialize a `gsap.quickTo()` function outside the event listener and call the resulting setter function inside the listener. This updates the target values without allocating new tween instances every time, drastically improving performance.
+
+## 2026-04-06 - Avoid gsap.to() in Magnetic Navigation Listeners
+
+**Learning:** Similar to the mouse parallax issue, using `gsap.to()` directly inside the `mousemove` event listener for magnetic navigation in `js/magnetic-nav.js` continuously instantiates new tween objects for every frame or event. This leads to main-thread jank and overhead for high-frequency interactive features like the magnetic social icons.
+
+**Action:** Replace `gsap.to()` inside the `mousemove` event listener with `gsap.quickTo()` pre-initialized outside the listener, reducing memory churn and improving performance by reusing pre-initialized setter functions for high-frequency updates. Keep the regular `gsap.to()` for `mouseleave` since it happens less frequently and relies on different easing/duration values.

--- a/js/magnetic-nav.js
+++ b/js/magnetic-nav.js
@@ -40,15 +40,15 @@ export function initMagneticNav() {
 
         const setChildX = child
             ? window.gsap.quickTo(child, 'x', {
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            })
+                  duration: 0.3,
+                  ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+              })
             : null;
         const setChildY = child
             ? window.gsap.quickTo(child, 'y', {
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            })
+                  duration: 0.3,
+                  ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+              })
             : null;
 
         el.addEventListener('mousemove', (e) => {

--- a/js/magnetic-nav.js
+++ b/js/magnetic-nav.js
@@ -31,21 +31,25 @@ export function initMagneticNav() {
          */
         const setX = window.gsap.quickTo(el, 'x', {
             duration: 0.3,
-            ease: 'cubic-bezier(0.65, 0.05, 0, 1)'
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
         });
         const setY = window.gsap.quickTo(el, 'y', {
             duration: 0.3,
-            ease: 'cubic-bezier(0.65, 0.05, 0, 1)'
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
         });
 
-        const setChildX = child ? window.gsap.quickTo(child, 'x', {
-            duration: 0.3,
-            ease: 'cubic-bezier(0.65, 0.05, 0, 1)'
-        }) : null;
-        const setChildY = child ? window.gsap.quickTo(child, 'y', {
-            duration: 0.3,
-            ease: 'cubic-bezier(0.65, 0.05, 0, 1)'
-        }) : null;
+        const setChildX = child
+            ? window.gsap.quickTo(child, 'x', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            })
+            : null;
+        const setChildY = child
+            ? window.gsap.quickTo(child, 'y', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            })
+            : null;
 
         el.addEventListener('mousemove', (e) => {
             const rect = el.getBoundingClientRect();

--- a/js/magnetic-nav.js
+++ b/js/magnetic-nav.js
@@ -38,18 +38,18 @@ export function initMagneticNav() {
             ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
         });
 
-        const setChildX = child
-            ? window.gsap.quickTo(child, 'x', {
-                  duration: 0.3,
-                  ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-              })
-            : null;
-        const setChildY = child
-            ? window.gsap.quickTo(child, 'y', {
-                  duration: 0.3,
-                  ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-              })
-            : null;
+        let setChildX = null;
+        let setChildY = null;
+        if (child) {
+            setChildX = window.gsap.quickTo(child, 'x', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+            setChildY = window.gsap.quickTo(child, 'y', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+        }
 
         el.addEventListener('mousemove', (e) => {
             const rect = el.getBoundingClientRect();

--- a/js/magnetic-nav.js
+++ b/js/magnetic-nav.js
@@ -21,6 +21,32 @@ export function initMagneticNav() {
     const magneticElements = document.querySelectorAll('.social-icons-container a');
 
     magneticElements.forEach((el) => {
+        const child = el.querySelector('i, span, img');
+
+        /**
+         * Bolt Optimization:
+         * - What: Replace `gsap.to()` inside the `mousemove` listener with `gsap.quickTo()`.
+         * - Why: Calling `gsap.to()` on every `mousemove` event instantiates a new tween object, causing memory churn, garbage collection overhead, and main-thread jank.
+         * - Impact: Measurably reduces memory allocations and CPU usage by reusing pre-initialized setter functions for high-frequency updates.
+         */
+        const setX = window.gsap.quickTo(el, 'x', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)'
+        });
+        const setY = window.gsap.quickTo(el, 'y', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)'
+        });
+
+        const setChildX = child ? window.gsap.quickTo(child, 'x', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)'
+        }) : null;
+        const setChildY = child ? window.gsap.quickTo(child, 'y', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)'
+        }) : null;
+
         el.addEventListener('mousemove', (e) => {
             const rect = el.getBoundingClientRect();
 
@@ -36,27 +62,20 @@ export function initMagneticNav() {
             // Strength of pull factor (lower = less pull)
             const strength = 0.4;
 
-            window.gsap.to(el, {
-                x: distX * strength,
-                y: distY * strength,
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            });
+            setX(distX * strength);
+            setY(distY * strength);
 
             // Pull the child element (e.g. <i>) slightly more for a parallax effect
-            const child = el.querySelector('i, span, img');
             if (child) {
-                window.gsap.to(child, {
-                    x: distX * (strength * 1.5),
-                    y: distY * (strength * 1.5),
-                    duration: 0.3,
-                    ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-                });
+                setChildX(distX * (strength * 1.5));
+                setChildY(distY * (strength * 1.5));
             }
         });
 
         el.addEventListener('mouseleave', () => {
             // Elastic snap back to origin
+            // We use standard gsap.to here because it has a different duration (0.7s vs 0.3s)
+            // and we want a different animation curve/timing for the snap back
             window.gsap.to(el, {
                 x: 0,
                 y: 0,
@@ -64,7 +83,6 @@ export function initMagneticNav() {
                 ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
             });
 
-            const child = el.querySelector('i, span, img');
             if (child) {
                 window.gsap.to(child, {
                     x: 0,

--- a/tests/js/magnetic-nav.test.js
+++ b/tests/js/magnetic-nav.test.js
@@ -23,6 +23,7 @@ describe('js/magnetic-nav.js', () => {
 
         mockGSAP = {
             to: jest.fn(),
+            quickTo: jest.fn().mockImplementation(() => jest.fn()),
         };
 
         context = {
@@ -103,6 +104,21 @@ describe('js/magnetic-nav.js', () => {
         };
         context.document.querySelectorAll = jest.fn().mockReturnValue([mockElement]);
 
+        const mockSetX = jest.fn();
+        const mockSetY = jest.fn();
+        const mockSetChildX = jest.fn();
+        const mockSetChildY = jest.fn();
+
+        mockGSAP.quickTo = jest.fn().mockImplementation((target, prop) => {
+            if (target === mockElement) {
+                return prop === 'x' ? mockSetX : mockSetY;
+            }
+            if (target === mockChild) {
+                return prop === 'x' ? mockSetChildX : mockSetChildY;
+            }
+            return jest.fn();
+        });
+
         vm.createContext(context);
         vm.runInContext(code, context);
 
@@ -122,27 +138,13 @@ describe('js/magnetic-nav.js', () => {
         // distX = 10, distY = 10
         // strength = 0.4
         // x = 4, y = 4
-        expect(mockGSAP.to).toHaveBeenCalledWith(
-            mockElement,
-            expect.objectContaining({
-                x: 4,
-                y: 4,
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            })
-        );
+        expect(mockSetX).toHaveBeenCalledWith(4);
+        expect(mockSetY).toHaveBeenCalledWith(4);
 
         // child parallax: strength * 1.5 = 0.6
         // x = 6, y = 6
-        expect(mockGSAP.to).toHaveBeenCalledWith(
-            mockChild,
-            expect.objectContaining({
-                x: expect.closeTo(6, 5),
-                y: expect.closeTo(6, 5),
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            })
-        );
+        expect(mockSetChildX).toHaveBeenCalledWith(expect.closeTo(6, 5));
+        expect(mockSetChildY).toHaveBeenCalledWith(expect.closeTo(6, 5));
     });
 
     test('snaps back on mouseleave', () => {


### PR DESCRIPTION
💡 What: Replaced `gsap.to()` calls inside the high-frequency `mousemove` event listener with `gsap.quickTo()` in `js/magnetic-nav.js`.
🎯 Why: Calling `gsap.to()` on every mouse movement instantiates a new tween object each time. This creates memory churn, increases garbage collection frequency, and can cause main-thread jank during continuous interaction, particularly on low-end devices.
📊 Impact: Measurably reduces main-thread overhead and memory allocations by pre-initializing the GSAP setters and reusing them.
🔬 Measurement: Verify smooth magnetic behavior on the main page social icons by hovering and moving the cursor within the hit area. CPU utilization during this movement will be lower than before.

Fixes the performance overhead associated with the magnetic navigation component's tracking logic.

---
*PR created automatically by Jules for task [381627632887691936](https://jules.google.com/task/381627632887691936) started by @ryusoh*