### PR TITLE
Palette: Remove viewport zoom restrictions for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2026-04-17 - [Accessibility: Viewport Zoom Restriction]
+
+**Learning:** To maintain WCAG compliance and ensure accessibility for low-vision users, strictly avoid using `user-scalable=no`, `maximum-scale=1.0`, or `minimum-scale=1` in viewport `<meta>` tags. These properties disable native pinch-to-zoom capabilities.
+**Action:** When inspecting a document's HTML structure, ensure the `<meta name="viewport">` tag does not restrict zooming, e.g., by ensuring it only contains `width=device-width, initial-scale=1.0, minimal-ui` or similar non-restrictive properties.

--- a/index.html
+++ b/index.html
@@ -27,10 +27,7 @@
             http-equiv="Content-Security-Policy"
             content="default-src 'self'; script-src 'self' https://www.google-analytics.com https://static.cloudflareinsights.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com https://fonts.bunny.net https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://fonts.bunny.net https://cdnjs.cloudflare.com; img-src 'self' data: https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1, user-scalable=no, minimal-ui"
-        />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
Removes user-scalable=no, maximum-scale=1.0, and minimum-scale=1 from the viewport meta tag in index.html to allow native pinch-to-zoom capabilities, ensuring WCAG compliance for low-vision users.

---
*PR created automatically by Jules for task [8251013676781139433](https://jules.google.com/task/8251013676781139433) started by @ryusoh*