### PR TITLE
test: improve coverage for block-navigation and quantum_particles

### DIFF
--- a/tests/js/ambient/quantum_particles.test.js
+++ b/tests/js/ambient/quantum_particles.test.js
@@ -202,6 +202,21 @@ describe('quantum_particles.js', () => {
             qp.updatePointerTarget({ clientX: 500, clientY: 250 }, target);
             expect(target.set).toHaveBeenCalledWith(0.5, 0.75); // 1 - 250/1000 = 0.75
         });
+
+        it('should clamp the target vector correctly based on coordinates outside bounds', () => {
+            const qp = getQuantumParticles();
+            const target = { set: jest.fn() };
+            window.innerWidth = 1000;
+            window.innerHeight = 1000;
+
+            // Negative bounds
+            qp.updatePointerTarget({ clientX: -100, clientY: 1500 }, target);
+            expect(target.set).toHaveBeenCalledWith(0, 0); // 1 - 1500/1000 = -0.5 -> 0
+
+            // Over bounds
+            qp.updatePointerTarget({ clientX: 1500, clientY: -100 }, target);
+            expect(target.set).toHaveBeenCalledWith(1, 1); // 1 - (-100)/1000 = 1.1 -> 1
+        });
     });
 
     describe('createParticleSystem', () => {

--- a/tests/js/block-navigation.test.js
+++ b/tests/js/block-navigation.test.js
@@ -23,9 +23,18 @@ describe('block-navigation', () => {
     });
 
     describe('calculateNextIndex', () => {
-        it('should return next index when pressing forward keys', () => {
-            expect(testing.calculateNextIndex).toBeDefined();
-            expect(typeof testing.calculateNextIndex).toBe('function');
+        it('should return correct index based on bounds for empty state', () => {
+            // blocks.length is 3 due to beforeEach document setup
+            expect(testing.calculateNextIndex('ArrowRight')).toBe(1);
+            expect(testing.calculateNextIndex('ArrowLeft')).toBe(0);
+        });
+    });
+
+    describe('getIndexFromFallback', () => {
+        it('should return correct fallback index', () => {
+            window.scrollY = 0;
+            window.innerHeight = 500;
+            expect(testing.getIndexFromFallback()).toBe(2);
         });
     });
 


### PR DESCRIPTION
This PR improves the test suite's coverage by addressing gaps found in utility functions `calculateNextIndex` and `getIndexFromFallback` in `block-navigation.js`, and bounded boundary clamping tests for `updatePointerTarget` in `quantum_particles.js`. Tests now properly simulate actual component logic rather than strictly testing typing bounds.

---
*PR created automatically by Jules for task [7511510552341339669](https://jules.google.com/task/7511510552341339669) started by @ryusoh*