### PR TITLE
Palette: Add visual tooltips for keyboard navigation shortcuts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2026-11-24 - [Accessibility: Discoverability of Keyboard Shortcuts]
+
+**Learning:** While using `aria-keyshortcuts` explicitly declares keyboard shortcuts to assistive technologies, it remains completely hidden from sighted users. Relying exclusively on this attribute provides a good non-visual experience but a poor overall UX, as most users will never discover the feature.
+**Action:** Always pair hidden keyboard shortcut declarations (like `aria-keyshortcuts`) with native visual tooltips (using the `title` attribute) on interactive elements. For example, append `(Escape)` or `(Right Arrow)` to the element's title to ensure the functionality is discoverable by all users without compromising the design.

--- a/p1/index.html
+++ b/p1/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (Right Arrow)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (Right Arrow)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (Right Arrow)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p4/index.html
+++ b/p4/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (Right Arrow)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 


### PR DESCRIPTION
Adds visual tooltips for keyboard navigation shortcuts to improve discoverability for sighted users, pairing with existing `aria-keyshortcuts`. Also includes a journal update documenting this accessibility finding.

---
*PR created automatically by Jules for task [9889045510399586528](https://jules.google.com/task/9889045510399586528) started by @ryusoh*