### PR TITLE
Bolt: Optimize magnetic-nav with gsap.quickTo

### DIFF
--- a/js/magnetic-nav.js
+++ b/js/magnetic-nav.js
@@ -21,6 +21,36 @@ export function initMagneticNav() {
     const magneticElements = document.querySelectorAll('.social-icons-container a');
 
     magneticElements.forEach((el) => {
+        const setX = window.gsap.quickTo(el, 'x', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+        const setY = window.gsap.quickTo(el, 'y', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+
+        const child = el.querySelector('i, span, img');
+        let setChildX;
+        let setChildY;
+
+        if (child) {
+            setChildX = window.gsap.quickTo(child, 'x', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+            setChildY = window.gsap.quickTo(child, 'y', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+        }
+
+        /**
+         * Bolt Optimization:
+         * - What: Replace `gsap.to()` inside the `mousemove` listener with `gsap.quickTo()`.
+         * - Why: Calling `gsap.to()` on every `mousemove` event instantiates a new tween object, causing memory churn, garbage collection overhead, and main-thread jank.
+         * - Impact: Measurably reduces memory allocations and CPU usage by reusing pre-initialized setter functions for high-frequency updates.
+         */
         el.addEventListener('mousemove', (e) => {
             const rect = el.getBoundingClientRect();
 
@@ -36,22 +66,13 @@ export function initMagneticNav() {
             // Strength of pull factor (lower = less pull)
             const strength = 0.4;
 
-            window.gsap.to(el, {
-                x: distX * strength,
-                y: distY * strength,
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            });
+            setX(distX * strength);
+            setY(distY * strength);
 
             // Pull the child element (e.g. <i>) slightly more for a parallax effect
-            const child = el.querySelector('i, span, img');
-            if (child) {
-                window.gsap.to(child, {
-                    x: distX * (strength * 1.5),
-                    y: distY * (strength * 1.5),
-                    duration: 0.3,
-                    ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-                });
+            if (child && setChildX && setChildY) {
+                setChildX(distX * (strength * 1.5));
+                setChildY(distY * (strength * 1.5));
             }
         });
 
@@ -64,7 +85,6 @@ export function initMagneticNav() {
                 ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
             });
 
-            const child = el.querySelector('i, span, img');
             if (child) {
                 window.gsap.to(child, {
                     x: 0,

--- a/tests/js/magnetic-nav.test.js
+++ b/tests/js/magnetic-nav.test.js
@@ -23,6 +23,9 @@ describe('js/magnetic-nav.js', () => {
 
         mockGSAP = {
             to: jest.fn(),
+            quickTo: jest.fn(() => {
+                return jest.fn();
+            }),
         };
 
         context = {
@@ -101,12 +104,23 @@ describe('js/magnetic-nav.js', () => {
                 height: 50,
             }),
         };
+
+        const mockSetters = [];
+        mockGSAP.quickTo = jest.fn(() => {
+            const setter = jest.fn();
+            mockSetters.push(setter);
+            return setter;
+        });
+
         context.document.querySelectorAll = jest.fn().mockReturnValue([mockElement]);
 
         vm.createContext(context);
         vm.runInContext(code, context);
 
         context.initMagneticNav();
+
+        // Check if quickTo was called 4 times (x and y for el, x and y for child)
+        expect(mockGSAP.quickTo).toHaveBeenCalledTimes(4);
 
         // Get the mousemove listener
         const mouseMoveHandler = mockElement.addEventListener.mock.calls.find(
@@ -119,27 +133,16 @@ describe('js/magnetic-nav.js', () => {
             clientY: 135,
         });
 
+        // The setters should have been called with the calculated values.
         // distX = 10, distY = 10, strength = 0.4 → x = 4, y = 4
-        expect(mockGSAP.to).toHaveBeenCalledWith(
-            mockElement,
-            expect.objectContaining({
-                x: 4,
-                y: 4,
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            })
-        );
+        // mockSetters[0] is setX, mockSetters[1] is setY
+        expect(mockSetters[0]).toHaveBeenCalledWith(4);
+        expect(mockSetters[1]).toHaveBeenCalledWith(4);
 
         // child parallax: strength * 1.5 = 0.6 → x = 6, y = 6
-        expect(mockGSAP.to).toHaveBeenCalledWith(
-            mockChild,
-            expect.objectContaining({
-                x: expect.closeTo(6, 5),
-                y: expect.closeTo(6, 5),
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            })
-        );
+        // mockSetters[2] is setChildX, mockSetters[3] is setChildY
+        expect(mockSetters[2]).toHaveBeenCalledWith(expect.closeTo(6, 5));
+        expect(mockSetters[3]).toHaveBeenCalledWith(expect.closeTo(6, 5));
     });
 
     test('snaps back on mouseleave', () => {


### PR DESCRIPTION
**What**: Replaced `gsap.to()` with `gsap.quickTo()` inside the high-frequency `mousemove` event listener for magnetic navigation. Also pre-computed the child element references outside the listener.
**Why**: Calling `gsap.to()` on every `mousemove` event instantiates a new tween object each time, leading to memory churn, increased garbage collection overhead, and main-thread jank during continuous mouse interactions.
**Impact**: Measurably reduces memory allocations and CPU usage by reusing pre-initialized setter functions for high-frequency updates, ensuring smoother magnetic animations.
**Measurement**: You can verify the improvement by running a memory profiler in the browser dev tools while aggressively moving the mouse over the social icons; memory allocations should be drastically reduced compared to the baseline. Tests were added to mock and verify `gsap.quickTo` behavior properly.

---
*PR created automatically by Jules for task [2067181938823384394](https://jules.google.com/task/2067181938823384394) started by @ryusoh*