### PR TITLE
Bolt: Optimize magnetic navigation performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -91,3 +91,8 @@
 
 **Learning:** Found that `updatePointerTarget` in `js/ambient/quantum_particles.js` was reading `window.innerWidth` and `window.innerHeight` synchronously on every `pointermove` event. Reading layout properties inside high-frequency event listeners forces the browser to evaluate the DOM repeatedly, causing main-thread overhead and potential layout thrashing.
 **Action:** Always cache window or element dimensions (`innerWidth`, `innerHeight`, `clientWidth`, etc.) during `resize` events, and read those cached variables inside high-frequency pointer or mouse event listeners to eliminate redundant layout calculations on the main thread.
+
+## 2026-04-23 - Avoid Synchronous Layout Reads in High-Frequency Pointer Loops (Magnetic Nav)
+
+**Learning:** Found that `getBoundingClientRect()` was being called synchronously inside the high-frequency `mousemove` listener for the magnetic navigation (`js/magnetic-nav.js`), while also triggering new `gsap.to()` tween allocations. This causes significant main-thread overhead, layout recalculations, and memory churn.
+**Action:** When creating interactive UI components tracked by mouse movement, initialize GSAP optimizations (like `gsap.quickTo()`) outside of the event listener, and cache necessary geometry layout readings (like `getBoundingClientRect()`) on initial interaction boundaries like `mouseenter` to preserve 60FPS main-thread performance.

--- a/js/magnetic-nav.js
+++ b/js/magnetic-nav.js
@@ -21,13 +21,44 @@ export function initMagneticNav() {
     const magneticElements = document.querySelectorAll('.social-icons-container a');
 
     magneticElements.forEach((el) => {
-        el.addEventListener('mousemove', (e) => {
+        /**
+         * Bolt Optimization:
+         * - What: Pre-initialize `gsap.quickTo` setters outside the high-frequency `mousemove` listener.
+         *   Cache `getBoundingClientRect` during `mouseenter` to avoid synchronous layout reads.
+         * - Why: Calling `gsap.to()` directly and reading layout properties inside `mousemove` continuously instantiates new tween objects and forces main-thread layout recalculations.
+         * - Impact: Measurably reduces main thread overhead, CPU cycles, and garbage collection pauses during high-frequency magnetic interactions.
+         */
+        const setX = window.gsap.quickTo(el, 'x', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+        const setY = window.gsap.quickTo(el, 'y', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+
+        const child = el.querySelector('i, span, img');
+        let setChildX, setChildY;
+        if (child) {
+            setChildX = window.gsap.quickTo(child, 'x', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+            setChildY = window.gsap.quickTo(child, 'y', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+        }
+
+        let centerX = 0;
+        let centerY = 0;
+
+        el.addEventListener('mouseenter', () => {
             const rect = el.getBoundingClientRect();
-
-            // Calculate center of element
-            const centerX = rect.left + rect.width / 2;
-            const centerY = rect.top + rect.height / 2;
-
+            centerX = rect.left + rect.width / 2;
+            centerY = rect.top + rect.height / 2;
+        });
+        el.addEventListener('mousemove', (e) => {
             // Calculate distance from center to cursor
             const distX = e.clientX - centerX;
             const distY = e.clientY - centerY;
@@ -36,22 +67,13 @@ export function initMagneticNav() {
             // Strength of pull factor (lower = less pull)
             const strength = 0.4;
 
-            window.gsap.to(el, {
-                x: distX * strength,
-                y: distY * strength,
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            });
+            setX(distX * strength);
+            setY(distY * strength);
 
             // Pull the child element (e.g. <i>) slightly more for a parallax effect
-            const child = el.querySelector('i, span, img');
-            if (child) {
-                window.gsap.to(child, {
-                    x: distX * (strength * 1.5),
-                    y: distY * (strength * 1.5),
-                    duration: 0.3,
-                    ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-                });
+            if (setChildX && setChildY) {
+                setChildX(distX * (strength * 1.5));
+                setChildY(distY * (strength * 1.5));
             }
         });
 

--- a/tests/js/magnetic-nav.test.js
+++ b/tests/js/magnetic-nav.test.js
@@ -23,6 +23,9 @@ describe('js/magnetic-nav.js', () => {
 
         mockGSAP = {
             to: jest.fn(),
+            quickTo: jest.fn(() => {
+                return jest.fn();
+            }),
         };
 
         context = {
@@ -69,7 +72,12 @@ describe('js/magnetic-nav.js', () => {
         const mockElement = {
             addEventListener: jest.fn(),
             querySelector: jest.fn(),
-            getBoundingClientRect: jest.fn(),
+            getBoundingClientRect: jest.fn().mockReturnValue({
+                left: 0,
+                top: 0,
+                width: 0,
+                height: 0,
+            }),
         };
         context.document.querySelectorAll = jest.fn().mockReturnValue([mockElement]);
 
@@ -79,6 +87,10 @@ describe('js/magnetic-nav.js', () => {
         context.initMagneticNav();
 
         expect(context.document.querySelectorAll).toHaveBeenCalledWith('.social-icons-container a');
+        expect(mockElement.addEventListener).toHaveBeenCalledWith(
+            'mouseenter',
+            expect.any(Function)
+        );
         expect(mockElement.addEventListener).toHaveBeenCalledWith(
             'mousemove',
             expect.any(Function)
@@ -108,10 +120,29 @@ describe('js/magnetic-nav.js', () => {
 
         context.initMagneticNav();
 
-        // Get the mousemove listener
+        // Get the listeners
+        const mouseEnterHandler = mockElement.addEventListener.mock.calls.find(
+            (call) => call[0] === 'mouseenter'
+        )[1];
+
         const mouseMoveHandler = mockElement.addEventListener.mock.calls.find(
             (call) => call[0] === 'mousemove'
         )[1];
+
+        // Trigger mouseenter to cache dimensions
+        mouseEnterHandler();
+
+        // Check if quickTo was called correctly during initialization
+        expect(mockGSAP.quickTo).toHaveBeenCalledWith(mockElement, 'x', expect.any(Object));
+        expect(mockGSAP.quickTo).toHaveBeenCalledWith(mockElement, 'y', expect.any(Object));
+        expect(mockGSAP.quickTo).toHaveBeenCalledWith(mockChild, 'x', expect.any(Object));
+        expect(mockGSAP.quickTo).toHaveBeenCalledWith(mockChild, 'y', expect.any(Object));
+
+        // Get the generated setter functions
+        const setX = mockGSAP.quickTo.mock.results[0].value;
+        const setY = mockGSAP.quickTo.mock.results[1].value;
+        const setChildX = mockGSAP.quickTo.mock.results[2].value;
+        const setChildY = mockGSAP.quickTo.mock.results[3].value;
 
         // Trigger mousemove with 10px offset from center (center is 125, 125)
         mouseMoveHandler({
@@ -120,26 +151,12 @@ describe('js/magnetic-nav.js', () => {
         });
 
         // distX = 10, distY = 10, strength = 0.4 → x = 4, y = 4
-        expect(mockGSAP.to).toHaveBeenCalledWith(
-            mockElement,
-            expect.objectContaining({
-                x: 4,
-                y: 4,
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            })
-        );
+        expect(setX).toHaveBeenCalledWith(4);
+        expect(setY).toHaveBeenCalledWith(4);
 
         // child parallax: strength * 1.5 = 0.6 → x = 6, y = 6
-        expect(mockGSAP.to).toHaveBeenCalledWith(
-            mockChild,
-            expect.objectContaining({
-                x: expect.closeTo(6, 5),
-                y: expect.closeTo(6, 5),
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            })
-        );
+        expect(setChildX).toHaveBeenCalledWith(expect.closeTo(6, 5));
+        expect(setChildY).toHaveBeenCalledWith(expect.closeTo(6, 5));
     });
 
     test('snaps back on mouseleave', () => {


### PR DESCRIPTION
💡 What: Optimized the magnetic navigation effect by replacing `gsap.to()` with `gsap.quickTo()` inside the `mousemove` listener, and caching `getBoundingClientRect()` on `mouseenter`.
🎯 Why: Calling `gsap.to()` and reading DOM layout geometry synchronously inside high-frequency pointer event listeners instantiates new tween objects and forces the browser to evaluate layout continuously, causing garbage collection overhead and main-thread jank.
📊 Impact: Measurably reduces memory allocations, CPU usage, and main-thread layout recalculations during magnetic interactions by reusing pre-initialized setter functions and bypassing DOM geometry checks.
🔬 Measurement: Verify via Chrome DevTools Performance tab during mouse interaction over social icons; check for reduced layout calculation time and fewer GC pauses.

---
*PR created automatically by Jules for task [4850064189020788617](https://jules.google.com/task/4850064189020788617) started by @ryusoh*