### PR TITLE
Palette: Enable native zooming on homepage

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2026-11-23 - [Accessibility: Viewport Zoom Restrictions]
+
+**Learning:** Using `maximum-scale=1.0`, `minimum-scale=1`, or `user-scalable=no` in the viewport `<meta>` tag prevents users from pinching to zoom on mobile devices. This is a severe accessibility violation for low-vision users who rely on zooming to read content and causes the application to fail WCAG Success Criterion 1.4.4 (Resize text).
+**Action:** Ensure the viewport `<meta>` tag is configured simply as `content="width=device-width, initial-scale=1.0"` (along with any other safe attributes like `minimal-ui`) and never restrict scaling.

--- a/index.html
+++ b/index.html
@@ -34,10 +34,7 @@
             http-equiv="Content-Security-Policy"
             content="default-src 'self'; script-src 'self' https://www.google-analytics.com https://static.cloudflareinsights.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com https://fonts.bunny.net https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://fonts.bunny.net https://cdnjs.cloudflare.com; img-src 'self' data: https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1, user-scalable=no, minimal-ui"
-        />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
**What**: Removed zoom restrictions (`maximum-scale=1.0`, `minimum-scale=1`, and `user-scalable=no`) from the `<meta name="viewport">` tag in `index.html`.

**Why**: Restricting pinch-to-zoom is an accessibility anti-pattern. Low-vision users rely heavily on native browser zoom to read and interact with web content on mobile devices.

**Accessibility**: This change directly resolves a WCAG Success Criterion 1.4.4 (Resize text) violation, making the site significantly more accessible to users with visual impairments.

---
*PR created automatically by Jules for task [9147498456844732266](https://jules.google.com/task/9147498456844732266) started by @ryusoh*