### PR TITLE
Palette: Add tooltips for keyboard shortcuts on navigation buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2024-05-18 - [Accessibility: Keyboard Shortcuts Discoverability]
+
+**Learning:** When adding hidden keyboard shortcuts via `aria-keyshortcuts` to interactive elements, they remain undiscoverable to sighted keyboard users or users who hover over elements unless explicitly announced.
+**Action:** Always pair hidden keyboard shortcuts (e.g., `aria-keyshortcuts`) on interactive elements with native visual tooltips (e.g., `title` attributes) to ensure discoverability for sighted users.

--- a/p1/index.html
+++ b/p1/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Escape)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (ArrowRight)" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Escape)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (ArrowRight)" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Escape)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (ArrowRight)" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p4/index.html
+++ b/p4/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Escape)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (ArrowRight)" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 


### PR DESCRIPTION
**💡 What**: Added `title` attributes (e.g., `title="Back to home (Escape)"`) to the navigation buttons across all project pages (`p1`, `p2`, `p3`, `p4`).

**🎯 Why**: The navigation buttons previously included hidden keyboard shortcuts via `aria-keyshortcuts` attributes (e.g., `Escape` and `ArrowRight`). These shortcuts were invisible and undiscoverable to sighted mouse users. Adding a `title` attribute natively exposes this information via a tooltip when users hover over the buttons, ensuring the functionality is discoverable.

**📸 Before/After**: Visually, the UI remains unchanged on page load (maintaining the minimalist aesthetic). Upon hovering over the left or right navigation chevrons, a native browser tooltip now appears displaying the text "Back to home (Escape)" or "Next project (ArrowRight)".

**♿ Accessibility**: This specifically addresses discoverability issues for sighted keyboard users and mouse users who might otherwise not realize keyboard shortcuts are available for navigation. Paired `aria-keyshortcuts` and `title` attributes ensure a balanced experience.

---
*PR created automatically by Jules for task [7875625420794068926](https://jules.google.com/task/7875625420794068926) started by @ryusoh*