### PR TITLE
Bolt: optimize magnetic navigation mousemove performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -91,3 +91,8 @@
 
 **Learning:** Found that `updatePointerTarget` in `js/ambient/quantum_particles.js` was reading `window.innerWidth` and `window.innerHeight` synchronously on every `pointermove` event. Reading layout properties inside high-frequency event listeners forces the browser to evaluate the DOM repeatedly, causing main-thread overhead and potential layout thrashing.
 **Action:** Always cache window or element dimensions (`innerWidth`, `innerHeight`, `clientWidth`, etc.) during `resize` events, and read those cached variables inside high-frequency pointer or mouse event listeners to eliminate redundant layout calculations on the main thread.
+
+## 2026-04-22 - Cache DOM Layout Reads in MouseEnter
+
+**Learning:** Found that the magnetic navigation in `js/magnetic-nav.js` was synchronously reading `el.getBoundingClientRect()` inside the high-frequency `mousemove` event listener. This forced the browser to continually recalculate the layout on the main thread during interactions, causing layout thrashing and overhead.
+**Action:** Always cache bounding boxes or element dimensions on initial interaction boundaries like `mouseenter` instead of calculating them continuously inside `mousemove` or pointer event listeners. This eliminates redundant layout calculations during the actual interaction.

--- a/js/magnetic-nav.js
+++ b/js/magnetic-nav.js
@@ -21,8 +21,45 @@ export function initMagneticNav() {
     const magneticElements = document.querySelectorAll('.social-icons-container a');
 
     magneticElements.forEach((el) => {
+        /**
+         * Bolt Optimization:
+         * - What: Replace `gsap.to()` inside the `mousemove` listener with `gsap.quickTo()`. Cache `getBoundingClientRect()` on `mouseenter`.
+         * - Why: Calling `gsap.to()` on every `mousemove` instantiates a new tween object, causing memory churn and main-thread jank. Synchronous DOM reads (`getBoundingClientRect`) inside `mousemove` cause layout thrashing.
+         * - Impact: Measurably reduces memory allocations and CPU usage by reusing pre-initialized setter functions for high-frequency updates and avoiding synchronous layout reads on every frame.
+         */
+        const setX = window.gsap.quickTo(el, 'x', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+        const setY = window.gsap.quickTo(el, 'y', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+
+        const child = el.querySelector('i, span, img');
+        let setChildX = null;
+        let setChildY = null;
+        if (child) {
+            setChildX = window.gsap.quickTo(child, 'x', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+            setChildY = window.gsap.quickTo(child, 'y', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+        }
+
+        let rect = null;
+
+        el.addEventListener('mouseenter', () => {
+            rect = el.getBoundingClientRect();
+        });
+
         el.addEventListener('mousemove', (e) => {
-            const rect = el.getBoundingClientRect();
+            if (!rect) {
+                rect = el.getBoundingClientRect();
+            }
 
             // Calculate center of element
             const centerX = rect.left + rect.width / 2;
@@ -36,22 +73,13 @@ export function initMagneticNav() {
             // Strength of pull factor (lower = less pull)
             const strength = 0.4;
 
-            window.gsap.to(el, {
-                x: distX * strength,
-                y: distY * strength,
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            });
+            setX(distX * strength);
+            setY(distY * strength);
 
             // Pull the child element (e.g. <i>) slightly more for a parallax effect
-            const child = el.querySelector('i, span, img');
-            if (child) {
-                window.gsap.to(child, {
-                    x: distX * (strength * 1.5),
-                    y: distY * (strength * 1.5),
-                    duration: 0.3,
-                    ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-                });
+            if (setChildX && setChildY) {
+                setChildX(distX * (strength * 1.5));
+                setChildY(distY * (strength * 1.5));
             }
         });
 
@@ -64,7 +92,6 @@ export function initMagneticNav() {
                 ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
             });
 
-            const child = el.querySelector('i, span, img');
             if (child) {
                 window.gsap.to(child, {
                     x: 0,

--- a/tests/js/magnetic-nav.test.js
+++ b/tests/js/magnetic-nav.test.js
@@ -6,11 +6,39 @@
 // Actually, jest currently fails to parse export without babel. Let's add a simple babel config to fix it for all modules using export/import
 describe('js/magnetic-nav.js', () => {
     let mockGSAP;
+    let mockSetX;
+    let mockSetY;
+    let mockSetChildX;
+    let mockSetChildY;
 
     beforeEach(() => {
         jest.resetModules();
+        mockSetX = jest.fn();
+        mockSetY = jest.fn();
+        mockSetChildX = jest.fn();
+        mockSetChildY = jest.fn();
+
         mockGSAP = {
             to: jest.fn(),
+            quickTo: jest.fn((target, prop) => {
+                if (target.tagName === 'A') {
+                    if (prop === 'x') {
+                        return mockSetX;
+                    }
+                    if (prop === 'y') {
+                        return mockSetY;
+                    }
+                }
+                if (target.tagName === 'I') {
+                    if (prop === 'x') {
+                        return mockSetChildX;
+                    }
+                    if (prop === 'y') {
+                        return mockSetChildY;
+                    }
+                }
+                return jest.fn();
+            }),
         };
 
         window.gsap = mockGSAP;
@@ -70,19 +98,20 @@ describe('js/magnetic-nav.js', () => {
             height: 50,
         });
 
+        const mouseEnterEvent = new MouseEvent('mouseenter');
+        el.dispatchEvent(mouseEnterEvent);
+
         const mouseMoveEvent = new MouseEvent('mousemove', {
             clientX: 135,
             clientY: 135,
         });
         el.dispatchEvent(mouseMoveEvent);
 
-        expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 4, y: 4 }));
+        expect(mockSetX).toHaveBeenCalledWith(4);
+        expect(mockSetY).toHaveBeenCalledWith(4);
 
-        const child = document.getElementById('child');
-        expect(mockGSAP.to).toHaveBeenCalledWith(
-            child,
-            expect.objectContaining({ x: expect.closeTo(6, 5), y: expect.closeTo(6, 5) })
-        );
+        expect(mockSetChildX).toHaveBeenCalledWith(expect.closeTo(6, 5));
+        expect(mockSetChildY).toHaveBeenCalledWith(expect.closeTo(6, 5));
     });
 
     test('snaps back on mouseleave', () => {
@@ -123,8 +152,10 @@ describe('js/magnetic-nav.js', () => {
             height: 50,
         });
 
+        el.dispatchEvent(new MouseEvent('mouseenter'));
         el.dispatchEvent(new MouseEvent('mousemove', { clientX: 135, clientY: 135 }));
-        expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 4, y: 4 }));
+        expect(mockSetX).toHaveBeenCalledWith(4);
+        expect(mockSetY).toHaveBeenCalledWith(4);
 
         el.dispatchEvent(new MouseEvent('mouseleave'));
         expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 0, y: 0 }));


### PR DESCRIPTION
What: Replaced `gsap.to()` with `gsap.quickTo()` inside the `mousemove` listener in `magnetic-nav.js`, and cached `getBoundingClientRect()` on `mouseenter`.
Why: Calling `gsap.to()` instantiates a new tween object on every frame, causing memory churn and main-thread jank. Synchronously reading DOM layout (`getBoundingClientRect`) inside the high-frequency `mousemove` event causes layout thrashing.
Impact: Measurably reduces memory allocations and CPU usage by reusing pre-initialized setter functions for high-frequency updates and avoiding synchronous layout reads on every frame.
Measurement: Verify by profiling the mouse interaction on social icons using Chrome DevTools Performance panel, observing reduced memory allocation and dropped frames.

---
*PR created automatically by Jules for task [9187849360068602468](https://jules.google.com/task/9187849360068602468) started by @ryusoh*