### PR TITLE
🎨 Palette: Improve UX with pinch-to-zoom support and keyboard shortcut tooltips

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2026-11-23 - [Accessibility: Viewport Zoom Restriction]
+
+**Learning:** Disabling zooming on mobile devices with viewport meta tags (e.g., `user-scalable=no`, `maximum-scale=1.0`, `minimum-scale=1`) hinders accessibility, especially for low-vision users who rely on pinch-to-zoom capabilities.
+**Action:** Ensure viewport `<meta>` tags do not restrict zooming to maintain WCAG compliance and enable native pinch-to-zoom capabilities.

--- a/index.html
+++ b/index.html
@@ -34,10 +34,7 @@
             http-equiv="Content-Security-Policy"
             content="default-src 'self'; script-src 'self' https://www.google-analytics.com https://static.cloudflareinsights.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com https://fonts.bunny.net https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://fonts.bunny.net https://cdnjs.cloudflare.com; img-src 'self' data: https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1, user-scalable=no, minimal-ui"
-        />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="theme-color" content="#000000" />

--- a/p1/index.html
+++ b/p1/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (ArrowRight)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (ArrowRight)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (ArrowRight)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p4/index.html
+++ b/p4/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (ArrowRight)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 


### PR DESCRIPTION
### 💡 What:
1. Removed `user-scalable=no, maximum-scale=1.0, minimum-scale=1` from the viewport meta tag in the main `index.html`.
2. Added `title` attributes (`Back to home (Escape)` and `Next project (ArrowRight)`) to the icon-only navigation buttons in the sub-project pages (`p1` through `p4`).
3. Added a new entry in `.jules/palette.md` to document the critical learning about avoiding viewport zoom restrictions.

### 🎯 Why:
1. Zoom restrictions aggressively block native mobile pinch-to-zoom capabilities, preventing visually impaired users from scaling the UI, which fails WCAG AA standards.
2. The icon-only navigation buttons (`.nav-back` and `.nav-next`) had hidden keyboard shortcuts (`aria-keyshortcuts`) that were completely undiscoverable by sighted users without assistive technology. Adding visual tooltips exposes these shortcuts and improves learnability.

### ♿ Accessibility:
- Enables native mobile zoom scaling (WCAG 1.4.4 Resize text).
- Pairs visual tooltips with hidden `aria-keyshortcuts` to bridge the gap between keyboard-only and sighted user experiences.

---
*PR created automatically by Jules for task [4231874393308790186](https://jules.google.com/task/4231874393308790186) started by @ryusoh*