### PR TITLE
🎨 Palette: Improve accessibility with tooltips and zoomable viewport

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2025-03-09 - Enable Native Zooming by Removing Viewport Scale Restrictions
+
+**Learning:** Found that `user-scalable=no`, `maximum-scale=1.0`, and `minimum-scale=1` restrictions were present in the viewport meta tag of `index.html`. This creates a critical accessibility issue, as it prevents native pinch-to-zoom for low-vision users.
+**Action:** Always ensure viewport `<meta>` tags do not restrict zooming to maintain WCAG compliance and enable native zoom capabilities.

--- a/index.html
+++ b/index.html
@@ -34,10 +34,7 @@
             http-equiv="Content-Security-Policy"
             content="default-src 'self'; script-src 'self' https://www.google-analytics.com https://static.cloudflareinsights.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com https://fonts.bunny.net https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://fonts.bunny.net https://cdnjs.cloudflare.com; img-src 'self' data: https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1, user-scalable=no, minimal-ui"
-        />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="theme-color" content="#000000" />

--- a/p1/index.html
+++ b/p1/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Escape)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Escape)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Escape)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p4/index.html
+++ b/p4/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Escape)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 


### PR DESCRIPTION
💡 What: Enabled native pinch-to-zoom on mobile and added tooltips to portfolio navigation buttons that surface existing keyboard shortcuts.
🎯 Why: Viewport scale restrictions create significant barriers for low-vision users who rely on native zoom. Additionally, while the navigation arrows already had hidden keyboard shortcuts (`aria-keyshortcuts`), sighted mouse users had no way to discover them. The `title` attribute provides a native, zero-dependency tooltip.
♿ Accessibility:
- Restored WCAG compliance for zoom capabilities.
- Exposed hidden keyboard shortcuts to sighted users via native browser tooltips.

---
*PR created automatically by Jules for task [123367841755953502](https://jules.google.com/task/123367841755953502) started by @ryusoh*