### PR TITLE
🎨 Palette: Enhance accessibility and keyboard navigation discoverability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,9 +44,11 @@
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
 
 ## 2024-05-21 - [Accessibility: Viewport Zoom Restrictions]
+
 **Learning:** Restricting viewport zooming via `<meta name="viewport" content="... user-scalable=no, maximum-scale=1.0, minimum-scale=1">` actively harms low-vision users who rely on native browser pinch-to-zoom capabilities, causing immediate WCAG failures.
 **Action:** Always ensure viewport meta tags use standard configurations (`content="width=device-width, initial-scale=1.0"`) and explicitly remove restrictive zooming properties when auditing accessibility.
 
 ## 2024-05-21 - [Accessibility: Hidden Shortcuts on Interactive Elements]
+
 **Learning:** Screen-reader-only hints (like `aria-keyshortcuts`) fail to aid sighted keyboard users who might benefit from the same shortcuts but lack the visual cue to discover them.
 **Action:** When adding `aria-keyshortcuts` to interactive navigation elements, always pair them with native visual tooltips via `title` attributes (e.g., `title="Back to home (Esc)"`) to guarantee discoverability for all users.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,11 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2024-05-21 - [Accessibility: Viewport Zoom Restrictions]
+**Learning:** Restricting viewport zooming via `<meta name="viewport" content="... user-scalable=no, maximum-scale=1.0, minimum-scale=1">` actively harms low-vision users who rely on native browser pinch-to-zoom capabilities, causing immediate WCAG failures.
+**Action:** Always ensure viewport meta tags use standard configurations (`content="width=device-width, initial-scale=1.0"`) and explicitly remove restrictive zooming properties when auditing accessibility.
+
+## 2024-05-21 - [Accessibility: Hidden Shortcuts on Interactive Elements]
+**Learning:** Screen-reader-only hints (like `aria-keyshortcuts`) fail to aid sighted keyboard users who might benefit from the same shortcuts but lack the visual cue to discover them.
+**Action:** When adding `aria-keyshortcuts` to interactive navigation elements, always pair them with native visual tooltips via `title` attributes (e.g., `title="Back to home (Esc)"`) to guarantee discoverability for all users.

--- a/index.html
+++ b/index.html
@@ -34,10 +34,7 @@
             http-equiv="Content-Security-Policy"
             content="default-src 'self'; script-src 'self' https://www.google-analytics.com https://static.cloudflareinsights.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com https://fonts.bunny.net https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://fonts.bunny.net https://cdnjs.cloudflare.com; img-src 'self' data: https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1, user-scalable=no, minimal-ui"
-        />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="theme-color" content="#000000" />

--- a/p1/index.html
+++ b/p1/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Esc)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (→)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Esc)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (→)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Esc)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (→)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p4/index.html
+++ b/p4/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Esc)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (→)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 


### PR DESCRIPTION
💡 **What**:
- Removed restrictive zooming properties (`user-scalable=no`, `maximum-scale=1.0`, `minimum-scale=1`) from the global viewport meta tag.
- Added visual `title` tooltips (`title="Back to home (Esc)"` and `title="Next project (→)"`) to the project navigation arrows.

🎯 **Why**:
- Restricting zoom is a critical accessibility barrier for users with low vision who rely on browser zoom features, failing WCAG compliance.
- While the project navigation arrows previously supported keyboard shortcuts (via `aria-keyshortcuts`), sighted keyboard users had no visual way of knowing these shortcuts existed. Adding native `title` tooltips pairs the hidden accessibility data with visual discoverability.

♿ **Accessibility**:
- Unlocked native browser zooming capabilities.
- Improved discoverability of keyboard shortcuts for all users.

---
*PR created automatically by Jules for task [18030797759045271115](https://jules.google.com/task/18030797759045271115) started by @ryusoh*