### PR TITLE
Palette: Enable native viewport pinch-to-zoom accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2025-05-05 - [Accessibility: Viewport Native Pinch-to-Zoom]
+
+**Learning:** When operating as the 'Palette' persona, ensure viewport `<meta>` tags do not restrict zooming (`user-scalable=no`, `maximum-scale=1.0`, or `minimum-scale=1`). While these are sometimes used to prevent input zoom on mobile forms, they severely limit accessibility by preventing native pinch-to-zoom capabilities, making the interface unusable for low-vision users and violating WCAG compliance.
+**Action:** Always verify that viewport meta tags are set cleanly to `width=device-width, initial-scale=1` without zoom restrictions to enable native accessibility features for all users.

--- a/index.html
+++ b/index.html
@@ -34,10 +34,7 @@
             http-equiv="Content-Security-Policy"
             content="default-src 'self'; script-src 'self' https://www.google-analytics.com https://static.cloudflareinsights.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com https://fonts.bunny.net https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://fonts.bunny.net https://cdnjs.cloudflare.com; img-src 'self' data: https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1, user-scalable=no, minimal-ui"
-        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
💡 What: Removed restrictive scaling attributes (`user-scalable=no`, `maximum-scale=1.0`, `minimum-scale=1`) from the viewport meta tag in `index.html` and recorded the learning.
🎯 Why: Restricting viewport scaling prevents native pinch-to-zoom capabilities, making the interface unusable for low-vision users and violating WCAG accessibility compliance.
♿ Accessibility: Enables full native pinch-to-zoom for all users on mobile devices.

---
*PR created automatically by Jules for task [13393700531557423502](https://jules.google.com/task/13393700531557423502) started by @ryusoh*