### PR TITLE
Bolt: Optimize magnetic navigation GSAP animations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -91,3 +91,13 @@
 
 **Learning:** Found that `updatePointerTarget` in `js/ambient/quantum_particles.js` was reading `window.innerWidth` and `window.innerHeight` synchronously on every `pointermove` event. Reading layout properties inside high-frequency event listeners forces the browser to evaluate the DOM repeatedly, causing main-thread overhead and potential layout thrashing.
 **Action:** Always cache window or element dimensions (`innerWidth`, `innerHeight`, `clientWidth`, etc.) during `resize` events, and read those cached variables inside high-frequency pointer or mouse event listeners to eliminate redundant layout calculations on the main thread.
+
+## 2024-05-06 - Optimized Magnetic Nav GSAP instantiations
+
+**Learning:** Instantiating new GSAP tweens (via `gsap.to()`) inside a high-frequency event listener like `mousemove` causes memory churn and garbage collection overhead.
+**Action:** Move `querySelector` out of the listener block, and replace `gsap.to()` with `gsap.quickTo()` which returns a highly-performant setter function that skips instantiation and directly applies changes on each tick.
+
+## 2024-05-06 - Mocking GSAP quickTo in Jest
+
+**Learning:** When unit testing GSAP's `quickTo` function, simple jest mocks (like `jest.fn()`) will lose track of the specific setter function calls for different elements. Assertions check if `quickTo` was called, but fail to verify the actual values calculated within the high-frequency event listeners.
+**Action:** Expose a Map on the mock object (e.g. `mockGSAP._setters`) and mock `quickTo` to return a cached setter function associated with a specific key (like `target.tagName-prop`). This allows for explicit test assertions against the generated setter functions to verify internal coordinate logic.

--- a/js/magnetic-nav.js
+++ b/js/magnetic-nav.js
@@ -21,6 +21,36 @@ export function initMagneticNav() {
     const magneticElements = document.querySelectorAll('.social-icons-container a');
 
     magneticElements.forEach((el) => {
+        /**
+         * Bolt Optimization:
+         * - What: Move DOM queries outside the event listener and replace `gsap.to()` with `gsap.quickTo()`.
+         * - Why: Querying the DOM and instantiating new GSAP tweens on every `mousemove` tick causes memory churn and main-thread jank.
+         * - Impact: Measurably reduces memory allocations and CPU usage during high-frequency events.
+         */
+        const child = el.querySelector('i, span, img');
+
+        const setElX = window.gsap.quickTo(el, 'x', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+        const setElY = window.gsap.quickTo(el, 'y', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+
+        let setChildX;
+        let setChildY;
+        if (child) {
+            setChildX = window.gsap.quickTo(child, 'x', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+            setChildY = window.gsap.quickTo(child, 'y', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+        }
+
         el.addEventListener('mousemove', (e) => {
             const rect = el.getBoundingClientRect();
 
@@ -36,22 +66,13 @@ export function initMagneticNav() {
             // Strength of pull factor (lower = less pull)
             const strength = 0.4;
 
-            window.gsap.to(el, {
-                x: distX * strength,
-                y: distY * strength,
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            });
+            setElX(distX * strength);
+            setElY(distY * strength);
 
             // Pull the child element (e.g. <i>) slightly more for a parallax effect
-            const child = el.querySelector('i, span, img');
             if (child) {
-                window.gsap.to(child, {
-                    x: distX * (strength * 1.5),
-                    y: distY * (strength * 1.5),
-                    duration: 0.3,
-                    ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-                });
+                setChildX(distX * (strength * 1.5));
+                setChildY(distY * (strength * 1.5));
             }
         });
 
@@ -64,7 +85,6 @@ export function initMagneticNav() {
                 ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
             });
 
-            const child = el.querySelector('i, span, img');
             if (child) {
                 window.gsap.to(child, {
                     x: 0,

--- a/tests/js/magnetic-nav.test.js
+++ b/tests/js/magnetic-nav.test.js
@@ -86,7 +86,6 @@ describe('js/magnetic-nav.js', () => {
         expect(mockGSAP._setters['A-x']).toHaveBeenCalledWith(4);
         expect(mockGSAP._setters['A-y']).toHaveBeenCalledWith(4);
 
-        const child = document.getElementById('child');
         expect(mockGSAP._setters['I-x']).toHaveBeenCalledWith(expect.closeTo(6, 5));
         expect(mockGSAP._setters['I-y']).toHaveBeenCalledWith(expect.closeTo(6, 5));
     });

--- a/tests/js/magnetic-nav.test.js
+++ b/tests/js/magnetic-nav.test.js
@@ -9,8 +9,15 @@ describe('js/magnetic-nav.js', () => {
 
     beforeEach(() => {
         jest.resetModules();
+        const setters = {};
         mockGSAP = {
             to: jest.fn(),
+            _setters: setters,
+            quickTo: jest.fn().mockImplementation((target, prop) => {
+                const key = `${target.tagName || 'unknown'}-${prop}`;
+                setters[key] = jest.fn();
+                return setters[key];
+            }),
         };
 
         window.gsap = mockGSAP;
@@ -76,13 +83,12 @@ describe('js/magnetic-nav.js', () => {
         });
         el.dispatchEvent(mouseMoveEvent);
 
-        expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 4, y: 4 }));
+        expect(mockGSAP._setters['A-x']).toHaveBeenCalledWith(4);
+        expect(mockGSAP._setters['A-y']).toHaveBeenCalledWith(4);
 
         const child = document.getElementById('child');
-        expect(mockGSAP.to).toHaveBeenCalledWith(
-            child,
-            expect.objectContaining({ x: expect.closeTo(6, 5), y: expect.closeTo(6, 5) })
-        );
+        expect(mockGSAP._setters['I-x']).toHaveBeenCalledWith(expect.closeTo(6, 5));
+        expect(mockGSAP._setters['I-y']).toHaveBeenCalledWith(expect.closeTo(6, 5));
     });
 
     test('snaps back on mouseleave', () => {
@@ -124,7 +130,8 @@ describe('js/magnetic-nav.js', () => {
         });
 
         el.dispatchEvent(new MouseEvent('mousemove', { clientX: 135, clientY: 135 }));
-        expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 4, y: 4 }));
+        expect(mockGSAP._setters['A-x']).toHaveBeenCalledWith(4);
+        expect(mockGSAP._setters['A-y']).toHaveBeenCalledWith(4);
 
         el.dispatchEvent(new MouseEvent('mouseleave'));
         expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 0, y: 0 }));


### PR DESCRIPTION
💡 What: Replaced `gsap.to()` with `gsap.quickTo()` and cached `querySelector` outside the `mousemove` event listener in `js/magnetic-nav.js`.
🎯 Why: Instantiating a new GSAP tween via `gsap.to()` and querying the DOM on every `mousemove` event tick causes memory allocations, garbage collection thrashing, and unnecessary main-thread CPU overhead, leading to subtle jank.
📊 Impact: Measurably reduces memory allocations and JS execution time during hover animations by reusing highly-performant setter functions instead of generating new animation objects on every frame.
🔬 Measurement: Verify by profiling the JS main thread in DevTools while vigorously hovering over the social links; CPU usage and memory allocations will be noticeably smoother/flatter compared to the old baseline.

---
*PR created automatically by Jules for task [10368746533533346270](https://jules.google.com/task/10368746533533346270) started by @ryusoh*