### PR TITLE
Palette: Add visual tooltips for keyboard shortcuts on project navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2026-11-23 - [UX/Accessibility: Keyboard Shortcut Discoverability]
+
+**Learning:** While `aria-keyshortcuts` provides crucial context for screen reader users regarding keyboard navigation (like using Escape or Arrow keys to navigate galleries), sighted mouse or trackpad users remain completely unaware of these shortcuts unless explicitly documented.
+**Action:** When operating as the 'Palette' persona to improve keyboard accessibility, always pair hidden keyboard shortcuts (e.g., `aria-keyshortcuts`) on interactive elements (like icon-only navigation buttons) with native visual tooltips (e.g., `title` attributes) indicating both the action and the shortcut key. This ensures discoverability for sighted users without requiring complex custom UI elements.

--- a/p1/index.html
+++ b/p1/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Esc)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Esc)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Esc)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p4/index.html
+++ b/p4/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Esc)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 


### PR DESCRIPTION
💡 **What:** Added native `title` attributes (e.g., `title="Back to home (Esc)"` and `title="Next project (Right Arrow)"`) to the project navigation icons.
🎯 **Why:** The buttons previously utilized `aria-keyshortcuts` for screen readers, but sighted users had no visual indication that they could use the keyboard (Escape to go back, Arrow keys to navigate) to control the immersive project view. This simple addition greatly enhances keyboard discoverability.
📸 **Before/After:** Icon-only buttons now feature native browser tooltips upon hover, preserving the clean aesthetic while providing critical UX instruction.
♿ **Accessibility:** Surfaces existing keyboard accessibility features to sighted/cognitive users.

Also recorded a new critical learning in `.jules/palette.md` advocating for pairing `aria-keyshortcuts` with native tooltips for future micro-UX improvements.

---
*PR created automatically by Jules for task [1485912053893190526](https://jules.google.com/task/1485912053893190526) started by @ryusoh*