### PR TITLE
Add unit test coverage for ambient and page transition modules

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -78,3 +78,8 @@
 
 **Learning:** Running \`pnpm test -- --coverage\` fails with 'No tests found' because Jest interprets \`--coverage\` as a test regex match due to argument interception issues.
 **Action:** Always use \`npx jest --coverage\` directly to successfully generate coverage reports.
+
+## 2025-02-24 - Testing Module-Level Event Listeners in JSDOM
+
+**Learning:** When testing global event handlers attached within an IIFE upon file require (`require('module.js')`), `jest.resetModules()` prevents caching issues, but JSDOM does not clear `document` or `window` event listeners between test blocks since the global `document` instance is shared. This causes event listener leaks where multiple versions of closures are triggered during `dispatchEvent`, leading to falsely preventing defaults.
+**Action:** Replace `document.addEventListener` with a mock function during `beforeEach` to intercept and locally capture the active listener array, then explicitly invoke `activeListener(event)` rather than relying on natural `dispatchEvent` bubbling to prevent cross-test contamination.

--- a/tests/js/ambient/ambient.test.js
+++ b/tests/js/ambient/ambient.test.js
@@ -226,4 +226,101 @@ describe('js/ambient/ambient.js', () => {
         expect(mockSketch.create).toHaveBeenCalled();
         expect(window.AmbientTransitionController).toBeDefined();
     });
+
+    describe('shouldSkip', () => {
+        let originalInnerWidth;
+        let originalMatchMedia;
+
+        beforeEach(() => {
+            originalInnerWidth = window.innerWidth;
+            originalMatchMedia = window.matchMedia;
+
+            Object.defineProperty(window, 'innerWidth', {
+                writable: true,
+                configurable: true,
+                value: 1200,
+            });
+
+            window.matchMedia = jest.fn().mockImplementation((query) => ({
+                matches: false,
+                media: query,
+            }));
+        });
+
+        afterEach(() => {
+            Object.defineProperty(window, 'innerWidth', {
+                writable: true,
+                configurable: true,
+                value: originalInnerWidth,
+            });
+            window.matchMedia = originalMatchMedia;
+        });
+
+        test('returns true if window.Sketch is not available', () => {
+            const originalSketch = window.Sketch;
+            delete window.Sketch;
+            expect(window.__AmbientForTesting.shouldSkip({ minWidth: 1024 }, false)).toBe(true);
+            window.Sketch = originalSketch;
+        });
+
+        test('returns false if force is true, bypassing other checks', () => {
+            window.innerWidth = 500;
+            expect(window.__AmbientForTesting.shouldSkip({ minWidth: 1024 }, true)).toBe(false);
+        });
+
+        test('returns true if disabled in config', () => {
+            expect(
+                window.__AmbientForTesting.shouldSkip({ minWidth: 1024, enabled: false }, false)
+            ).toBe(true);
+        });
+
+        test('returns true if prefers reduced motion is true and not explicitly bypassed', () => {
+            window.matchMedia = jest.fn().mockImplementation((query) => ({
+                matches: true,
+                media: query,
+            }));
+            jest.resetModules();
+            require('../../../js/ambient/ambient.js');
+            expect(
+                window.__AmbientForTesting.shouldSkip({ minWidth: 1024, enabled: true }, false)
+            ).toBe(true);
+        });
+
+        test('returns false if prefers reduced motion is true but config respects reduced motion is false', () => {
+            window.matchMedia = jest.fn().mockImplementation((query) => ({
+                matches: true,
+                media: query,
+            }));
+            jest.resetModules();
+            require('../../../js/ambient/ambient.js');
+            expect(
+                window.__AmbientForTesting.shouldSkip(
+                    { minWidth: 1024, enabled: true, respectReducedMotion: false },
+                    false
+                )
+            ).toBe(false);
+        });
+
+        test('returns true if window.innerWidth is less than config minWidth', () => {
+            window.innerWidth = 800;
+            expect(
+                window.__AmbientForTesting.shouldSkip({ minWidth: 1024, enabled: true }, false)
+            ).toBe(true);
+        });
+
+        test('returns false when all conditions are met', () => {
+            expect(
+                window.__AmbientForTesting.shouldSkip({ minWidth: 1024, enabled: true }, false)
+            ).toBe(false);
+        });
+
+        test('gracefully handles missing matchMedia', () => {
+            delete window.matchMedia;
+            jest.resetModules();
+            require('../../../js/ambient/ambient.js');
+            expect(
+                window.__AmbientForTesting.shouldSkip({ minWidth: 1024, enabled: true }, false)
+            ).toBe(false);
+        });
+    });
 });

--- a/tests/js/page-transition.test.js
+++ b/tests/js/page-transition.test.js
@@ -629,4 +629,195 @@ describe('page-transition.js', () => {
             jest.useRealTimers();
         });
     });
+
+    describe('Global click and pageshow event handlers', () => {
+        let originalMatchMedia;
+        let documentClickListeners = [];
+        let documentPageShowListeners = [];
+        let originalAddEventListener;
+
+        beforeEach(() => {
+            originalMatchMedia = window.matchMedia;
+            window.matchMedia = jest.fn().mockImplementation((query) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: jest.fn(),
+                removeListener: jest.fn(),
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+                dispatchEvent: jest.fn(),
+            }));
+
+            documentClickListeners = [];
+            documentPageShowListeners = [];
+            originalAddEventListener = document.addEventListener;
+
+            document.addEventListener = jest.fn((event, cb, options) => {
+                if (event === 'click') {
+                    documentClickListeners.push(cb);
+                }
+                if (event === 'pageshow') {
+                    documentPageShowListeners.push(cb);
+                }
+                originalAddEventListener.call(document, event, cb, options);
+            });
+
+            const originalWindowAddEventListener = window.addEventListener;
+            window.addEventListener = jest.fn((event, cb, options) => {
+                if (event === 'pageshow') {
+                    documentPageShowListeners.push(cb);
+                }
+                originalWindowAddEventListener.call(window, event, cb, options);
+            });
+
+            jest.resetModules();
+            document.documentElement.innerHTML = '<body></body>';
+            document.documentElement.className = '';
+            document.body = document.createElement('body');
+            document.documentElement.appendChild(document.body);
+            require('../../js/page-transition.js');
+        });
+
+        afterEach(() => {
+            window.matchMedia = originalMatchMedia;
+            document.addEventListener = originalAddEventListener;
+        });
+
+        test('should navigate and prevent default when clicking an eligible anchor with data-page-transition', () => {
+            const anchor = document.createElement('a');
+            anchor.href = 'https://example.com/test';
+            anchor.setAttribute('data-page-transition', 'true');
+            document.body.appendChild(anchor);
+
+            const event = {
+                target: { closest: () => anchor },
+                preventDefault: function () {
+                    this.defaultPrevented = true;
+                },
+                defaultPrevented: false,
+                button: 0,
+            };
+            documentClickListeners[documentClickListeners.length - 1](event);
+
+            expect(event.defaultPrevented).toBe(true);
+            expect(document.documentElement.classList.contains('page-transition--exiting')).toBe(
+                true
+            );
+        });
+
+        test('should not prevent default if anchor does not have data-page-transition attribute', () => {
+            const anchor = document.createElement('a');
+            anchor.href = 'https://example.com/test';
+            document.body.appendChild(anchor);
+
+            const event = {
+                target: { closest: () => anchor },
+                preventDefault: function () {
+                    this.defaultPrevented = true;
+                },
+                defaultPrevented: false,
+                button: 0,
+            };
+            documentClickListeners[documentClickListeners.length - 1](event);
+
+            expect(event.defaultPrevented).toBe(false);
+            expect(document.documentElement.classList.contains('page-transition--exiting')).toBe(
+                false
+            );
+        });
+
+        test('should not navigate if anchor is not eligible (e.g., target="_blank")', () => {
+            const anchor = document.createElement('a');
+            anchor.href = 'https://example.com/test';
+            anchor.setAttribute('data-page-transition', 'true');
+            anchor.setAttribute('target', '_blank');
+            document.body.appendChild(anchor);
+
+            const event = {
+                target: { closest: () => anchor },
+                preventDefault: function () {
+                    this.defaultPrevented = true;
+                },
+                defaultPrevented: false,
+                button: 0,
+            };
+            documentClickListeners[documentClickListeners.length - 1](event);
+
+            expect(event.defaultPrevented).toBe(false);
+            expect(document.documentElement.classList.contains('page-transition--exiting')).toBe(
+                false
+            );
+        });
+
+        test('should not navigate if there is a pending animation', () => {
+            const anchor1 = document.createElement('a');
+            anchor1.href = 'https://example.com/test1';
+            anchor1.setAttribute('data-page-transition', 'true');
+
+            const event1 = {
+                target: { closest: () => anchor1 },
+                preventDefault: function () {
+                    this.defaultPrevented = true;
+                },
+                defaultPrevented: false,
+                button: 0,
+            };
+
+            const activeClickListener = documentClickListeners[documentClickListeners.length - 1];
+
+            activeClickListener(event1);
+            expect(event1.defaultPrevented).toBe(true);
+
+            const anchor2 = document.createElement('a');
+            anchor2.href = 'https://example.com/test2';
+            anchor2.setAttribute('data-page-transition', 'true');
+
+            const event2 = {
+                target: { closest: () => anchor2 },
+                preventDefault: function () {
+                    this.defaultPrevented = true;
+                },
+                defaultPrevented: false,
+                button: 0,
+            };
+
+            activeClickListener(event2);
+            expect(event2.defaultPrevented).toBe(false);
+        });
+
+        test('pageshow event should reset exiting class and isAnimating', () => {
+            document.documentElement.classList.add('page-transition--exiting');
+
+            const pageshowEvent = {
+                persisted: true,
+            };
+
+            const activePageShowListener =
+                documentPageShowListeners[documentPageShowListeners.length - 1];
+            activePageShowListener(pageshowEvent);
+
+            expect(document.documentElement.classList.contains('page-transition--exiting')).toBe(
+                false
+            );
+
+            const anchor = document.createElement('a');
+            anchor.href = 'https://example.com/test-after-pageshow';
+            anchor.setAttribute('data-page-transition', 'true');
+
+            const clickEvent = {
+                target: { closest: () => anchor },
+                preventDefault: function () {
+                    this.defaultPrevented = true;
+                },
+                defaultPrevented: false,
+                button: 0,
+            };
+
+            const activeClickListener = documentClickListeners[documentClickListeners.length - 1];
+            activeClickListener(clickEvent);
+
+            expect(clickEvent.defaultPrevented).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
Implemented unit test coverage for 3 target logic blocks:
1. `page-transition.js` global `click` delegation
2. `page-transition.js` `pageshow` transition reset logic
3. `ambient.js` `shouldSkip` configuration block

Ensured 100% boundary testing with no modification to application source code.
Updated testing logs to reflect JSDOM listener isolation patterns.

---
*PR created automatically by Jules for task [5952699284409684441](https://jules.google.com/task/5952699284409684441) started by @ryusoh*