### PR TITLE
Bolt: optimize magnetic navigation with gsap.quickTo()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -91,6 +91,7 @@
 
 **Learning:** Found that `updatePointerTarget` in `js/ambient/quantum_particles.js` was reading `window.innerWidth` and `window.innerHeight` synchronously on every `pointermove` event. Reading layout properties inside high-frequency event listeners forces the browser to evaluate the DOM repeatedly, causing main-thread overhead and potential layout thrashing.
 **Action:** Always cache window or element dimensions (`innerWidth`, `innerHeight`, `clientWidth`, etc.) during `resize` events, and read those cached variables inside high-frequency pointer or mouse event listeners to eliminate redundant layout calculations on the main thread.
+
 ## 2026-05-11 - Avoid gsap.to() in Magnetic Navigation Listeners
 
 **Learning:** Similar to the mouse parallax issue, using `gsap.to()` directly inside the `mousemove` event listener for magnetic navigation in `js/magnetic-nav.js` continuously instantiates new tween objects for every frame or event. This leads to main-thread jank and overhead for high-frequency interactive features like the magnetic social icons.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -91,3 +91,8 @@
 
 **Learning:** Found that `updatePointerTarget` in `js/ambient/quantum_particles.js` was reading `window.innerWidth` and `window.innerHeight` synchronously on every `pointermove` event. Reading layout properties inside high-frequency event listeners forces the browser to evaluate the DOM repeatedly, causing main-thread overhead and potential layout thrashing.
 **Action:** Always cache window or element dimensions (`innerWidth`, `innerHeight`, `clientWidth`, etc.) during `resize` events, and read those cached variables inside high-frequency pointer or mouse event listeners to eliminate redundant layout calculations on the main thread.
+## 2026-05-11 - Avoid gsap.to() in Magnetic Navigation Listeners
+
+**Learning:** Similar to the mouse parallax issue, using `gsap.to()` directly inside the `mousemove` event listener for magnetic navigation in `js/magnetic-nav.js` continuously instantiates new tween objects for every frame or event. This leads to main-thread jank and overhead for high-frequency interactive features like the magnetic social icons.
+
+**Action:** Replace `gsap.to()` inside the `mousemove` event listener with `gsap.quickTo()` pre-initialized outside the listener, reducing memory churn and improving performance by reusing pre-initialized setter functions for high-frequency updates. Keep the regular `gsap.to()` for `mouseleave` since it happens less frequently and relies on different easing/duration values.

--- a/js/magnetic-nav.js
+++ b/js/magnetic-nav.js
@@ -21,6 +21,34 @@ export function initMagneticNav() {
     const magneticElements = document.querySelectorAll('.social-icons-container a');
 
     magneticElements.forEach((el) => {
+        /**
+         * Bolt Optimization:
+         * - What: Replace gsap.to() inside the mousemove listener with gsap.quickTo() pre-initialized outside.
+         * - Why: Using gsap.to() directly inside the mousemove event listener continuously instantiates new tween objects for every frame or event, leading to main-thread jank.
+         * - Impact: Reduces memory churn and improves performance by reusing pre-initialized setter functions for high-frequency updates.
+         */
+        const setElX = window.gsap.quickTo(el, 'x', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+        const setElY = window.gsap.quickTo(el, 'y', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+
+        const child = el.querySelector('i, span, img');
+        let setChildX, setChildY;
+        if (child) {
+            setChildX = window.gsap.quickTo(child, 'x', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+            setChildY = window.gsap.quickTo(child, 'y', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+        }
+
         el.addEventListener('mousemove', (e) => {
             const rect = el.getBoundingClientRect();
 
@@ -36,22 +64,13 @@ export function initMagneticNav() {
             // Strength of pull factor (lower = less pull)
             const strength = 0.4;
 
-            window.gsap.to(el, {
-                x: distX * strength,
-                y: distY * strength,
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            });
+            setElX(distX * strength);
+            setElY(distY * strength);
 
             // Pull the child element (e.g. <i>) slightly more for a parallax effect
-            const child = el.querySelector('i, span, img');
-            if (child) {
-                window.gsap.to(child, {
-                    x: distX * (strength * 1.5),
-                    y: distY * (strength * 1.5),
-                    duration: 0.3,
-                    ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-                });
+            if (child && setChildX && setChildY) {
+                setChildX(distX * (strength * 1.5));
+                setChildY(distY * (strength * 1.5));
             }
         });
 

--- a/tests/js/magnetic-nav.test.js
+++ b/tests/js/magnetic-nav.test.js
@@ -6,11 +6,20 @@
 // Actually, jest currently fails to parse export without babel. Let's add a simple babel config to fix it for all modules using export/import
 describe('js/magnetic-nav.js', () => {
     let mockGSAP;
+    let mockQuickToSetters;
 
     beforeEach(() => {
         jest.resetModules();
+        mockQuickToSetters = new Map();
         mockGSAP = {
             to: jest.fn(),
+            quickTo: jest.fn((target, prop) => {
+                const key = `${target.id || target.tagName}-${prop}`;
+                if (!mockQuickToSetters.has(key)) {
+                    mockQuickToSetters.set(key, jest.fn());
+                }
+                return mockQuickToSetters.get(key);
+            }),
         };
 
         window.gsap = mockGSAP;
@@ -76,13 +85,12 @@ describe('js/magnetic-nav.js', () => {
         });
         el.dispatchEvent(mouseMoveEvent);
 
-        expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 4, y: 4 }));
+        expect(mockGSAP.quickTo).toHaveBeenCalled();
+        expect(mockQuickToSetters.get('A-x')).toHaveBeenCalledWith(4);
+        expect(mockQuickToSetters.get('A-y')).toHaveBeenCalledWith(4);
 
-        const child = document.getElementById('child');
-        expect(mockGSAP.to).toHaveBeenCalledWith(
-            child,
-            expect.objectContaining({ x: expect.closeTo(6, 5), y: expect.closeTo(6, 5) })
-        );
+        expect(mockQuickToSetters.get('child-x')).toHaveBeenCalledWith(expect.closeTo(6, 5));
+        expect(mockQuickToSetters.get('child-y')).toHaveBeenCalledWith(expect.closeTo(6, 5));
     });
 
     test('snaps back on mouseleave', () => {
@@ -124,7 +132,8 @@ describe('js/magnetic-nav.js', () => {
         });
 
         el.dispatchEvent(new MouseEvent('mousemove', { clientX: 135, clientY: 135 }));
-        expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 4, y: 4 }));
+        expect(mockQuickToSetters.get('A-x')).toHaveBeenCalledWith(4);
+        expect(mockQuickToSetters.get('A-y')).toHaveBeenCalledWith(4);
 
         el.dispatchEvent(new MouseEvent('mouseleave'));
         expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 0, y: 0 }));


### PR DESCRIPTION
### 💡 What:
Replaced `gsap.to()` calls inside the high-frequency `mousemove` event listener in `js/magnetic-nav.js` with `gsap.quickTo()` pre-initialized outside the listener. Also pulled `el.querySelector` out of the listener.

### 🎯 Why:
Calling `gsap.to()` directly inside a `mousemove` event listener instantiates a new tween object on every frame or event, which causes severe memory churn, Garbage Collection pauses, and main-thread jank. Similarly, running DOM queries repeatedly in a hot loop is unnecessary.

### 📊 Impact:
Measurably reduces memory allocations and main-thread overhead by reusing pre-initialized setter functions for high-frequency interactive features like the magnetic social icons.

### 🔬 Measurement:
Run the performance profiler in DevTools on the homepage during interaction with the social icons. You will see significantly fewer object allocations and reduced GC activity compared to `gsap.to`. Tests pass (`pnpm test`), and JS/CSS formats are maintained (`pnpm fmt:check`).

---
*PR created automatically by Jules for task [10401938223163605264](https://jules.google.com/task/10401938223163605264) started by @ryusoh*