### PR TITLE
Bolt: Optimize magnetic navigation using gsap.quickTo

### DIFF
--- a/js/magnetic-nav.js
+++ b/js/magnetic-nav.js
@@ -21,6 +21,30 @@ export function initMagneticNav() {
     const magneticElements = document.querySelectorAll('.social-icons-container a');
 
     magneticElements.forEach((el) => {
+        // Pre-initialize GSAP setters for high-performance updates
+        const setX = window.gsap.quickTo(el, 'x', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+        const setY = window.gsap.quickTo(el, 'y', {
+            duration: 0.3,
+            ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+        });
+
+        // Pre-initialize setters for child element if it exists
+        const child = el.querySelector('i, span, img');
+        let setChildX, setChildY;
+        if (child) {
+            setChildX = window.gsap.quickTo(child, 'x', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+            setChildY = window.gsap.quickTo(child, 'y', {
+                duration: 0.3,
+                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
+            });
+        }
+
         el.addEventListener('mousemove', (e) => {
             const rect = el.getBoundingClientRect();
 
@@ -32,26 +56,17 @@ export function initMagneticNav() {
             const distX = e.clientX - centerX;
             const distY = e.clientY - centerY;
 
-            // Apply magnetic pull using GSAP
+            // Apply magnetic pull using GSAP quickTo
             // Strength of pull factor (lower = less pull)
             const strength = 0.4;
 
-            window.gsap.to(el, {
-                x: distX * strength,
-                y: distY * strength,
-                duration: 0.3,
-                ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-            });
+            setX(distX * strength);
+            setY(distY * strength);
 
             // Pull the child element (e.g. <i>) slightly more for a parallax effect
-            const child = el.querySelector('i, span, img');
-            if (child) {
-                window.gsap.to(child, {
-                    x: distX * (strength * 1.5),
-                    y: distY * (strength * 1.5),
-                    duration: 0.3,
-                    ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
-                });
+            if (child && setChildX && setChildY) {
+                setChildX(distX * (strength * 1.5));
+                setChildY(distY * (strength * 1.5));
             }
         });
 

--- a/tests/js/magnetic-nav.test.js
+++ b/tests/js/magnetic-nav.test.js
@@ -9,8 +9,17 @@ describe('js/magnetic-nav.js', () => {
 
     beforeEach(() => {
         jest.resetModules();
+        const setters = new Map();
+
         mockGSAP = {
             to: jest.fn(),
+            quickTo: jest.fn().mockImplementation((target, prop) => {
+                const key = `${target.id || target.tagName}-${prop}`;
+                const setter = jest.fn();
+                setters.set(key, setter);
+                return setter;
+            }),
+            _setters: setters,
         };
 
         window.gsap = mockGSAP;
@@ -76,13 +85,11 @@ describe('js/magnetic-nav.js', () => {
         });
         el.dispatchEvent(mouseMoveEvent);
 
-        expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 4, y: 4 }));
+        expect(mockGSAP._setters.get('A-x')).toHaveBeenCalledWith(4);
+        expect(mockGSAP._setters.get('A-y')).toHaveBeenCalledWith(4);
 
-        const child = document.getElementById('child');
-        expect(mockGSAP.to).toHaveBeenCalledWith(
-            child,
-            expect.objectContaining({ x: expect.closeTo(6, 5), y: expect.closeTo(6, 5) })
-        );
+        expect(mockGSAP._setters.get('child-x')).toHaveBeenCalledWith(expect.closeTo(6, 5));
+        expect(mockGSAP._setters.get('child-y')).toHaveBeenCalledWith(expect.closeTo(6, 5));
     });
 
     test('snaps back on mouseleave', () => {
@@ -124,7 +131,8 @@ describe('js/magnetic-nav.js', () => {
         });
 
         el.dispatchEvent(new MouseEvent('mousemove', { clientX: 135, clientY: 135 }));
-        expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 4, y: 4 }));
+        expect(mockGSAP._setters.get('A-x')).toHaveBeenCalledWith(4);
+        expect(mockGSAP._setters.get('A-y')).toHaveBeenCalledWith(4);
 
         el.dispatchEvent(new MouseEvent('mouseleave'));
         expect(mockGSAP.to).toHaveBeenCalledWith(el, expect.objectContaining({ x: 0, y: 0 }));


### PR DESCRIPTION
💡 **What**: Replaced `window.gsap.to()` calls inside the `mousemove` event listener with `window.gsap.quickTo()` pre-initialized outside the listener in `js/magnetic-nav.js`. Also mocked `gsap.quickTo()` appropriately using a Map-based mock in `tests/js/magnetic-nav.test.js`.
🎯 **Why**: Using `gsap.to()` directly inside high-frequency event listeners continuously instantiates new tween objects for every frame or event. This leads to main-thread jank and overhead. `gsap.quickTo()` drastically improves performance by reusing pre-initialized setter functions.
📊 **Impact**: Reduces memory churn (object allocations) and CPU time spent parsing animation configurations during continuous interaction.
🔬 **Measurement**: Verify by inspecting Chrome DevTools Memory Profiler (fewer short-lived objects allocated on `mousemove` inside `.social-icons-container`) or via a Performance recording to observe shorter layout/script execution times on hover.

---
*PR created automatically by Jules for task [13337885379588193645](https://jules.google.com/task/13337885379588193645) started by @ryusoh*