### PR TITLE
Sentinel: [MEDIUM] Fix DoS via unbounded URL parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,6 +47,7 @@
 **Prevention:** Always wrap external `window.fetch` requests with an explicit timeout mechanism using `AbortController` and `setTimeout` (e.g., 5000ms), and ensure the timeout is cleaned up to prevent memory leaks.
 
 ## 2026-05-13 - [DoS via Unbounded URL Parsing]
+
 **Vulnerability:** The native `new window.URL()` constructor was repeatedly called with `window.location.href` to parse query parameters (e.g., `hasTransitionParam()`) without any length limitations. An attacker could craft an excessively long URL that forces the client to allocate significant memory and CPU time to parse it, causing a Denial of Service (DoS) and hanging the user's browser.
-**Learning:** Even built-in browser functions like `new window.URL()` can be computationally expensive when forced to parse arbitrarily massive strings. Protecting against DoS requires validating the size of the input *before* passing it to the parsing engine, just as we did for `URLSearchParams`.
+**Learning:** Even built-in browser functions like `new window.URL()` can be computationally expensive when forced to parse arbitrarily massive strings. Protecting against DoS requires validating the size of the input _before_ passing it to the parsing engine, just as we did for `URLSearchParams`.
 **Prevention:** Apply bounds checking (e.g., `window.location.href.length > 2000`) before passing dynamic, attacker-controlled strings like URLs into native parsing constructors.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -45,3 +45,8 @@
 **Vulnerability:** External `fetch` requests in `cdnFallback.js` lacked explicit timeouts. This could lead to client-side Denial of Service (DoS) and resource exhaustion if the remote server hung indefinitely, blocking the completion of the fallback CSS loading promise.
 **Learning:** By default, the native `fetch` API does not implement a timeout. In environments where network reliability is uncertain, failing to bound the duration of network requests leaves the application vulnerable to stalled execution paths.
 **Prevention:** Always wrap external `window.fetch` requests with an explicit timeout mechanism using `AbortController` and `setTimeout` (e.g., 5000ms), and ensure the timeout is cleaned up to prevent memory leaks.
+
+## 2026-05-13 - [DoS via Unbounded URL Parsing]
+**Vulnerability:** The native `new window.URL()` constructor was repeatedly called with `window.location.href` to parse query parameters (e.g., `hasTransitionParam()`) without any length limitations. An attacker could craft an excessively long URL that forces the client to allocate significant memory and CPU time to parse it, causing a Denial of Service (DoS) and hanging the user's browser.
+**Learning:** Even built-in browser functions like `new window.URL()` can be computationally expensive when forced to parse arbitrarily massive strings. Protecting against DoS requires validating the size of the input *before* passing it to the parsing engine, just as we did for `URLSearchParams`.
+**Prevention:** Apply bounds checking (e.g., `window.location.href.length > 2000`) before passing dynamic, attacker-controlled strings like URLs into native parsing constructors.

--- a/js/page-transition.js
+++ b/js/page-transition.js
@@ -79,6 +79,9 @@
             return false;
         }
         try {
+            if (window.location.href.length > 2000) {
+                return false;
+            }
             const url = new window.URL(window.location.href);
             return url.searchParams.has(TRANSITION_PARAM);
         } catch (e) {
@@ -99,6 +102,9 @@
             return;
         }
         try {
+            if (window.location.href.length > 2000) {
+                return;
+            }
             const url = new window.URL(window.location.href);
             if (!url.searchParams.has(TRANSITION_PARAM)) {
                 return;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `hasTransitionParam` and `clearTransitionParam` functions parsed `window.location.href` via `new window.URL()` without validating its length. This could allow an attacker to craft a massive URL string, causing excessive memory consumption and potential client-side Denial of Service (DoS) when the browser attempts to parse it.
🎯 Impact: Client-side performance degradation or browser freeze (DoS).
🔧 Fix: Implemented an early return check to ensure `window.location.href.length` does not exceed 2000 characters before invoking the URL constructor.
✅ Verification: Ran `pnpm test` successfully. Tests for `hasTransitionParam` and `clearTransitionParam` confirm functionality remains intact. Also verified linter compliance via `pnpm lint`.

---
*PR created automatically by Jules for task [2799726459342350572](https://jules.google.com/task/2799726459342350572) started by @ryusoh*