### PR TITLE
test: improve unit test coverage across multiple modules

### DIFF
--- a/tests/js/ambient/quantum_particles.test.js
+++ b/tests/js/ambient/quantum_particles.test.js
@@ -44,6 +44,45 @@ describe('quantum_particles.js', () => {
         return require('../../../js/ambient/quantum_particles.js');
     }
 
+    describe('ready', () => {
+        it('should execute function immediately if document.readyState is complete', () => {
+            const qp = getQuantumParticles();
+            const fn = jest.fn();
+            Object.defineProperty(document, 'readyState', {
+                get: () => 'complete',
+                configurable: true,
+            });
+            qp.ready(fn);
+            expect(fn).toHaveBeenCalled();
+        });
+
+        it('should execute function immediately if document.readyState is interactive', () => {
+            const qp = getQuantumParticles();
+            const fn = jest.fn();
+            Object.defineProperty(document, 'readyState', {
+                get: () => 'interactive',
+                configurable: true,
+            });
+            qp.ready(fn);
+            expect(fn).toHaveBeenCalled();
+        });
+
+        it('should add DOMContentLoaded listener if document.readyState is loading', () => {
+            const qp = getQuantumParticles();
+            const fn = jest.fn();
+            const addSpy = jest.spyOn(document, 'addEventListener');
+            Object.defineProperty(document, 'readyState', {
+                get: () => 'loading',
+                configurable: true,
+            });
+
+            qp.ready(fn);
+
+            expect(fn).not.toHaveBeenCalled();
+            expect(addSpy).toHaveBeenCalledWith('DOMContentLoaded', fn, { once: true });
+        });
+    });
+
     describe('clamp', () => {
         it('should return the value when it is within the bounds', () => {
             const qp = getQuantumParticles();

--- a/tests/js/block-navigation.test.js
+++ b/tests/js/block-navigation.test.js
@@ -140,6 +140,68 @@ describe('js/block-navigation.js', () => {
             const el = document.querySelector('.post-content p');
             expect(testing.shouldUseElement(el)).toBe(true);
         });
+        it('should return false if element is null', () => {
+            expect(testing.shouldUseElement(null)).toBe(false);
+        });
+
+        it('should return false for script, style, noscript tags', () => {
+            const script = document.createElement('script');
+            const style = document.createElement('style');
+            const noscript = document.createElement('noscript');
+            document.body.appendChild(script);
+            document.body.appendChild(style);
+            document.body.appendChild(noscript);
+
+            expect(testing.shouldUseElement(script)).toBe(false);
+            expect(testing.shouldUseElement(style)).toBe(false);
+            expect(testing.shouldUseElement(noscript)).toBe(false);
+        });
+
+        it('should return false if closest parent has data-block-nav="ignore"', () => {
+            const parent = document.createElement('div');
+            parent.setAttribute('data-block-nav', 'ignore');
+            const child = document.createElement('div');
+            parent.appendChild(child);
+            document.body.appendChild(parent);
+            expect(testing.shouldUseElement(child)).toBe(false);
+        });
+
+        it('should return true if element has data-block-nav="block"', () => {
+            const el = document.createElement('div');
+            el.setAttribute('data-block-nav', 'block');
+            document.body.appendChild(el);
+            expect(testing.shouldUseElement(el)).toBe(true);
+        });
+
+        it('should return false if closest parent has data-block-nav="block" but element itself does not', () => {
+            const parent = document.createElement('div');
+            parent.setAttribute('data-block-nav', 'block');
+            const child = document.createElement('div');
+            parent.appendChild(child);
+            document.body.appendChild(parent);
+            expect(testing.shouldUseElement(child)).toBe(false);
+        });
+
+        it('should return true for .post-heading only if it is not inside .intro-header', () => {
+            const div = document.createElement('div');
+            div.className = 'post-heading';
+            document.body.appendChild(div);
+            expect(testing.shouldUseElement(div)).toBe(true);
+
+            const introHeader = document.createElement('div');
+            introHeader.className = 'intro-header';
+            const childHeading = document.createElement('div');
+            childHeading.className = 'post-heading';
+            introHeader.appendChild(childHeading);
+            document.body.appendChild(introHeader);
+            expect(testing.shouldUseElement(childHeading)).toBe(false);
+        });
+
+        it('should return false for element not matching anything', () => {
+            const el = document.createElement('div');
+            document.body.appendChild(el);
+            expect(testing.shouldUseElement(el)).toBe(false);
+        });
     });
 
     describe('debounce', () => {

--- a/tests/js/font-awesome-loader.test.js
+++ b/tests/js/font-awesome-loader.test.js
@@ -163,7 +163,9 @@ describe('FontAwesomeLoader', () => {
             loader.waitForFontLoad();
 
             // Call onload
-            if (link.onload) { link.onload(); }
+            if (link.onload) {
+                link.onload();
+            }
 
             // Should not show icons again if already loaded
             expect(showSpy).not.toHaveBeenCalled();

--- a/tests/js/font-awesome-loader.test.js
+++ b/tests/js/font-awesome-loader.test.js
@@ -111,6 +111,66 @@ describe('FontAwesomeLoader', () => {
         expect(waitSpy).toHaveBeenCalled();
     });
 
+    describe('cleanupTestElement', () => {
+        it('should remove testElement from its parentNode and set it to null', () => {
+            const loader = new FontAwesomeLoader();
+            const parent = context.document.createElement('div');
+            const el = context.document.createElement('div');
+            parent.appendChild(el);
+            loader.testElement = el;
+
+            loader.cleanupTestElement();
+            expect(parent.contains(el)).toBe(false);
+            expect(loader.testElement).toBeNull();
+        });
+
+        it('should not throw if testElement is null', () => {
+            const loader = new FontAwesomeLoader();
+            loader.testElement = null;
+            expect(() => loader.cleanupTestElement()).not.toThrow();
+        });
+
+        it('should not throw if testElement has no parentNode', () => {
+            const loader = new FontAwesomeLoader();
+            const el = context.document.createElement('div');
+            loader.testElement = el;
+            expect(() => loader.cleanupTestElement()).not.toThrow();
+        });
+    });
+
+    describe('waitForFontLoad Error Handling', () => {
+        it('should not throw or error if no font-awesome link is found', () => {
+            const loader = new FontAwesomeLoader();
+
+            // clear links
+            context.document.documentElement.innerHTML = '<html><head></head><body></body></html>';
+
+            expect(() => loader.waitForFontLoad()).not.toThrow();
+        });
+
+        it('should handle font link load gracefully even if already loaded', () => {
+            const loader = new FontAwesomeLoader();
+            loader.fontAwesomeLoaded = true;
+
+            const link = context.document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = 'font-awesome.css';
+            context.document.head.appendChild(link);
+
+            const showSpy = jest.spyOn(loader, 'showIcons');
+            const stopSpy = jest.spyOn(loader, 'stopChecking');
+
+            loader.waitForFontLoad();
+
+            // Call onload
+            if (link.onload) { link.onload(); }
+
+            // Should not show icons again if already loaded
+            expect(showSpy).not.toHaveBeenCalled();
+            expect(stopSpy).not.toHaveBeenCalled();
+        });
+    });
+
     describe('waitForFontLoad', () => {
         beforeEach(() => {
             jest.useFakeTimers();


### PR DESCRIPTION
Implemented unit tests for exactly 3 distinct target areas:
1. `shouldUseElement` in `tests/js/block-navigation.test.js`
2. `cleanupTestElement` & `waitForFontLoad` in `tests/js/font-awesome-loader.test.js`
3. `ready` function in `tests/js/ambient/quantum_particles.test.js`

These tests adhere to strict standards, use Arrange-Act-Assert, avoid application logic modifications, and have been verified with `pnpm test` and `pnpm lint`.

---
*PR created automatically by Jules for task [18140216253483555557](https://jules.google.com/task/18140216253483555557) started by @ryusoh*