### PR TITLE
Palette: Add visual tooltips for keyboard shortcuts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2024-05-18 - [Accessibility: Exposing Keyboard Shortcuts]
+
+**Learning:** Hidden keyboard shortcuts (e.g., those defined by `aria-keyshortcuts`) can easily go unnoticed by users who aren't using screen readers.
+**Action:** Always pair hidden keyboard shortcuts on interactive elements with native visual tooltips (e.g., `title` attributes) to ensure they are accessible and discoverable for all users.

--- a/p1/index.html
+++ b/p1/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Esc)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (Right Arrow)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Esc)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (Right Arrow)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Esc)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (Right Arrow)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p4/index.html
+++ b/p4/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Esc)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (Right Arrow)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 


### PR DESCRIPTION
### 💡 What
Added native HTML `title` attributes matching the existing `aria-keyshortcuts` to the `nav-back` and `nav-next` arrows on all project pages (`p1/index.html` through `p4/index.html`). Additionally, added a new journal entry to `.jules/palette.md` noting the importance of visually exposing hidden keyboard shortcuts.

### 🎯 Why
Hidden keyboard shortcuts (like `Escape` or `ArrowRight` bindings) specified by `aria-keyshortcuts` are completely invisible to users who are not utilizing a screen reader. Adding a native HTML `title` tooltip allows standard sighted mouse users to discover these shortcuts without altering the minimal visual design of the interface, significantly reducing navigation friction.

### ♿ Accessibility
This enhances general usability. `aria-keyshortcuts` alone only provides context to assistive technologies. The `title` attribute acts as a visual tooltip for mouse users while `aria-label` continues to provide the accessible name for the button.

---
*PR created automatically by Jules for task [8676583698294781988](https://jules.google.com/task/8676583698294781988) started by @ryusoh*