### PR TITLE
Palette: Add discoverable visual tooltips for keyboard shortcuts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2026-11-23 - [Accessibility: Discoverability of aria-keyshortcuts]
+
+**Learning:** Using `aria-keyshortcuts` perfectly provides programmatic keyboard shortcut bindings for screen readers. However, sighted keyboard users and mouse users have zero visual indication that these shortcuts exist without reading the DOM or relying on extensive trial-and-error, severely diminishing their utility and the intended UX delight.
+**Action:** Always pair hidden `aria-keyshortcuts` with native visual tooltips via the `title` attribute (e.g., `title="Back to home (Escape)"`). This satisfies the "discoverability" requirement for all users without polluting the visual canvas or requiring custom tooltip components.

--- a/p1/index.html
+++ b/p1/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (ArrowRight)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (ArrowRight)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (ArrowRight)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p4/index.html
+++ b/p4/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home" title="Back to home (Escape)">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project" title="Next project (ArrowRight)">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 


### PR DESCRIPTION
💡 **What**: Added native `title` attributes (e.g., `title="Back to home (Escape)"`) to the persistent back and next navigation buttons on all project pages (`p1` through `p4`). Also appended a learning to the palette journal regarding shortcut discoverability.
🎯 **Why**: While `aria-keyshortcuts` were correctly applied for screen readers, sighted users (both mouse and keyboard-only) had zero visual indication that these shortcuts existed. This change surfaces the shortcuts natively without adding complex custom tooltip components or altering the strict visual design.
♿ **Accessibility**: Improves cognitive accessibility and discoverability by explicitly revealing keyboard shortcuts to sighted users upon hover or focus, bridging the gap between programmatic aria attributes and visible affordances.

---
*PR created automatically by Jules for task [10409474042473239955](https://jules.google.com/task/10409474042473239955) started by @ryusoh*