### PR TITLE
Sentinel: [HIGH] Fix DoS vulnerability in URL parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -51,3 +51,9 @@
 **Vulnerability:** The native `new window.URL()` constructor was repeatedly called with `window.location.href` to parse query parameters (e.g., `hasTransitionParam()`) without any length limitations. An attacker could craft an excessively long URL that forces the client to allocate significant memory and CPU time to parse it, causing a Denial of Service (DoS) and hanging the user's browser.
 **Learning:** Even built-in browser functions like `new window.URL()` can be computationally expensive when forced to parse arbitrarily massive strings. Protecting against DoS requires validating the size of the input _before_ passing it to the parsing engine, just as we did for `URLSearchParams`.
 **Prevention:** Apply bounds checking (e.g., `window.location.href.length > 2000`) before passing dynamic, attacker-controlled strings like URLs into native parsing constructors.
+
+## 2026-06-25 - [Incomplete DoS Prevention on URL Parsing]
+
+**Vulnerability:** While `window.location.search` was previously secured against massive lengths before parsing to prevent Denial of Service (DoS), the `window.location.href` and passed `url` string were passed to `new window.URL()` without length limits in `getValidatedUrl` and `buildTransitionUrl`. An attacker could exploit this by crafting a massive URL.
+**Learning:** Security fixes must be comprehensive across all similar patterns. Fixing a DoS vulnerability for `URLSearchParams` but leaving `new window.URL` exposed reveals a gap in identifying all vector surfaces for a single class of vulnerability (Unbounded Input to Native Parsers).
+**Prevention:** Apply rigorous pattern searching (`grep -rn 'new window.URL'`) when addressing DoS vulnerabilities to ensure all similar usages (e.g., `new window.URL`, `URLSearchParams`) enforce strict length boundaries (e.g., `> 2000` characters) on inputs derived from the environment.

--- a/js/page-transition.js
+++ b/js/page-transition.js
@@ -230,7 +230,14 @@
     }
 
     function getValidatedUrl(url) {
-        if (typeof url !== 'string') {
+        if (typeof url !== 'string' || url.length > 2000) {
+            return null;
+        }
+        if (
+            typeof window !== 'undefined' &&
+            window.location &&
+            window.location.href.length > 2000
+        ) {
             return null;
         }
         const cleanUrl = url.replace(/^[\s\u0000-\u001F]+/g, '');
@@ -250,6 +257,16 @@
     }
 
     function buildTransitionUrl(url) {
+        if (typeof url !== 'string' || url.length > 2000) {
+            return url;
+        }
+        if (
+            typeof window !== 'undefined' &&
+            window.location &&
+            window.location.href.length > 2000
+        ) {
+            return url;
+        }
         try {
             const nextUrl = new window.URL(url, window.location.href);
             nextUrl.searchParams.set(TRANSITION_PARAM, '1');

--- a/tests/js/page-transition.test.js
+++ b/tests/js/page-transition.test.js
@@ -231,6 +231,22 @@ describe('page-transition.js', () => {
             expect(getValidatedUrl(123)).toBeNull();
         });
 
+        test('returns null if url is longer than 2000 characters', () => {
+            const longUrl = '/page?' + 'a'.repeat(2000);
+            expect(getValidatedUrl(longUrl)).toBeNull();
+        });
+
+        test('returns null if window.location.href is longer than 2000 characters', () => {
+            const originalHref = window.location.href;
+            Object.defineProperty(window.location, 'href', {
+                value: 'http://localhost/?' + 'a'.repeat(2000),
+                configurable: true,
+                writable: true,
+            });
+            expect(getValidatedUrl('/page')).toBeNull();
+            window.location.href = originalHref;
+        });
+
         test('validates and returns clean same-origin URL', () => {
             expect(getValidatedUrl('/page')).toBe('/page');
             expect(getValidatedUrl('https://example.com/page')).toBe('https://example.com/page');
@@ -571,6 +587,22 @@ describe('page-transition.js', () => {
         test('should build url with transition param', () => {
             const url = buildTransitionUrl('/test');
             expect(url).toContain('__pt=1');
+        });
+
+        test('returns url untouched if it is longer than 2000 characters', () => {
+            const longUrl = '/test?' + 'a'.repeat(2000);
+            expect(buildTransitionUrl(longUrl)).toBe(longUrl);
+        });
+
+        test('returns url untouched if window.location.href is longer than 2000 characters', () => {
+            const originalHref = window.location.href;
+            Object.defineProperty(window.location, 'href', {
+                value: 'http://localhost/?' + 'a'.repeat(2000),
+                configurable: true,
+                writable: true,
+            });
+            expect(buildTransitionUrl('/test')).toBe('/test');
+            window.location.href = originalHref;
         });
 
         test('should gracefully handle URL parsing errors', () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `getValidatedUrl` and `buildTransitionUrl` functions were passing unbounded input strings (`url` and `window.location.href`) directly into the native `new window.URL()` parser. This made the application vulnerable to client-side Denial of Service (DoS) attacks, as an attacker could craft an excessively long URL to exhaust client memory and CPU resources.
🎯 Impact: Exploitation could cause the browser tab to hang or crash due to memory exhaustion, disrupting service availability for the user.
🔧 Fix: Implemented strict length limits (maximum 2000 characters) on both the input `url` string and the current `window.location.href` prior to parsing. If the limits are exceeded, `getValidatedUrl` safely returns `null` and `buildTransitionUrl` returns the unparsed URL, neutralizing the threat.
✅ Verification: Ensure the test suite passes (`pnpm test`), which includes new test cases simulating massive URL strings.

---
*PR created automatically by Jules for task [5329766708354911822](https://jules.google.com/task/5329766708354911822) started by @ryusoh*