### PR TITLE
Palette: Add visual tooltips to keyboard shortcuts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,8 @@
 
 **Learning:** When styling 'Skip to content' links (often with `.sr-only-focusable`), transitioning from `position: absolute` (with `.sr-only` constraints) to `position: static` on `:focus` causes the newly visible element to push down the entire layout. This creates a jarring visual jump for keyboard users and can temporarily break page layouts until focus moves again.
 **Action:** When styling the `:active` and `:focus` states for skip-to-content links, retain `position: absolute` but apply a high `z-index`, contrasting background/text colors, and padding. This ensures the link appears as a highly visible, floating overlay button that does not disrupt the surrounding document flow. Additionally, ensure target elements with `tabindex="-1"` receive an `outline: none !important;` rule to prevent the browser's default focus ring from enveloping the entire content area upon successful skip.
+
+## 2026-11-20 - [Keyboard Shortcut Discoverability]
+
+**Learning:** Hidden keyboard shortcuts (like `aria-keyshortcuts`) on interactive elements should be paired with native visual tooltips (`title` attributes).
+**Action:** Always add `title` attributes with the keyboard shortcut to elements with `aria-keyshortcuts` to ensure sighted users can discover them.

--- a/p1/index.html
+++ b/p1/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Esc)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p2/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p2/index.html
+++ b/p2/index.html
@@ -123,12 +123,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Esc)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p3/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p3/index.html
+++ b/p3/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Esc)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p4/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 

--- a/p4/index.html
+++ b/p4/index.html
@@ -117,12 +117,12 @@
 
         <!-- Navigation Buttons (Persistent during transitions) -->
         <!-- prettier-ignore -->
-        <a class="nav-back" aria-keyshortcuts="Escape" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
+        <a class="nav-back" aria-keyshortcuts="Escape" title="Back to home (Esc)" href="../" target="_self" data-page-transition data-destination="home" aria-label="Back to home">
             <i class="fa fa-chevron-left" aria-hidden="true"></i>
         </a>
 
         <!-- prettier-ignore -->
-        <a class="nav-next" aria-keyshortcuts="ArrowRight" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
+        <a class="nav-next" aria-keyshortcuts="ArrowRight" title="Next project (Right Arrow)" href="../p1/" target="_self" data-page-transition data-destination="project" aria-label="Next project">
             <i class="fa fa-chevron-right" aria-hidden="true"></i>
         </a>
 


### PR DESCRIPTION
💡 What: Added `title` attributes to the `.nav-back` and `.nav-next` buttons on all project pages to explicitly show the keyboard shortcuts ("Esc" and "Right Arrow").
🎯 Why: To improve the visual discoverability of existing hidden keyboard shortcuts (`aria-keyshortcuts`), making them easier for sighted users to find and use.
📸 Before/After: N/A
♿ Accessibility: The buttons now pair the screen-reader friendly `aria-keyshortcuts` with a visual `title` tooltip for all users.

---
*PR created automatically by Jules for task [3008472149958136059](https://jules.google.com/task/3008472149958136059) started by @ryusoh*