### PR TITLE
Enhance hover preview with organic clip-path transition

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -618,12 +618,13 @@ html.page-transition--exiting #main {
     pointer-events: none;
     z-index: 1000;
     opacity: 0;
-    transform: scale(0.8);
+    clip-path: ellipse(0% 0% at 50% 50%);
+    transform: scale(1);
     transform-origin: center center;
     border-radius: 8px;
     overflow: hidden;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
-    will-change: transform, opacity;
+    will-change: transform, opacity, clip-path;
 }
 
 .hover-preview-img {

--- a/js/hover-preview.js
+++ b/js/hover-preview.js
@@ -114,7 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             gsap.to(previewContainer, {
-                scale: 1,
+                clipPath: 'ellipse(150% 150% at 50% 50%)',
                 opacity: 1,
                 duration: 0.4,
                 ease: 'cubic-bezier(0.65, 0.05, 0, 1)',
@@ -135,7 +135,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         isHovering = false;
         gsap.to(previewContainer, {
-            scale: 0.8,
+            clipPath: 'ellipse(0% 0% at 50% 50%)',
             opacity: 0,
             duration: 0.3,
             ease: 'cubic-bezier(0.65, 0.05, 0, 1)',


### PR DESCRIPTION
This PR enhances the hover preview component by replacing the default, rectangular `transform: scale()` scaling with an organic `clip-path: ellipse` reveal transition.

Changes included:
- Updated `css/main_style.css` to initialize the hover container with a hidden `clip-path: ellipse(0% 0% at 50% 50%)` and added `clip-path` to the `will-change` optimizations to ensure GPU-backed performance.
- Updated `js/hover-preview.js` to animate the `clipPath` between `ellipse(0% 0% at 50% 50%)` and `ellipse(150% 150% at 50% 50%)` on mouse events.
- Ensured the transition continues to use the global `--brand-ease` cubic-bezier curve.

This change follows a principle of purposeful UI, providing a seamless editorial motion experience without overriding native scrolling or introducing artificial latency. All tests, linters, and formatting checks pass.

---
*PR created automatically by Jules for task [11504210590081764862](https://jules.google.com/task/11504210590081764862) started by @ryusoh*