### PR TITLE
Bolt: Replace .forEach with for loops in block-navigation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -111,3 +111,8 @@
 
 **Learning:** Found that `js/page-transition.js` was reading `document.body.offsetHeight` simply to force the browser to commit the starting state before applying staggered entrance styles. Calling layout properties synchronously like this forces the browser to prematurely calculate layouts, causing layout thrashing and blocking the main thread.
 **Action:** Replace synchronous layout reads (like `offsetHeight`) used purely to force style recalculation with a double `requestAnimationFrame` block. This guarantees the browser paints the initial state in the current frame and applies the new transition styles in the subsequent frame asynchronously, without forcing synchronous layout evaluations.
+
+## 2026-06-26 - Avoid .forEach in High-Frequency Callbacks
+
+**Learning:** Found that `js/block-navigation.js` used `.forEach()` inside `IntersectionObserver` callbacks and `scroll` event handlers. Using `.forEach()` allocates a new callback function closure on every invocation, which causes unnecessary memory churn and GC overhead when called frequently (like during continuous scrolling).
+**Action:** Replace `Array.prototype.forEach` and `Set.prototype.forEach` with traditional `for` or `for...of` loops in high-frequency event handlers or hot paths to eliminate function allocation overhead and reduce GC pressure.

--- a/js/block-navigation.js
+++ b/js/block-navigation.js
@@ -226,7 +226,14 @@
 
         observer = new window.IntersectionObserver((entries) => {
             let changed = false;
-            entries.forEach((entry) => {
+            /**
+             * Bolt Optimization:
+             * - What: Replace Array.prototype.forEach with a traditional for loop.
+             * - Why: The intersection observer callback can fire frequently during scrolling. Using .forEach allocates a new callback function closure on every invocation, causing memory churn and GC overhead.
+             * - Impact: Eliminates redundant function allocations during scroll events, slightly reducing main thread GC pressure.
+             */
+            for (let i = 0; i < entries.length; i++) {
+                const entry = entries[i];
                 const target = entry.target;
                 if (entry.isIntersecting) {
                     visibleBlocks.add(target);
@@ -235,7 +242,7 @@
                     visibleBlocks.delete(target);
                     changed = true;
                 }
-            });
+            }
 
             if (changed) {
                 syncCurrentIndex();
@@ -293,12 +300,18 @@
         }
 
         let bestIndex = 0;
-        visibleBlocks.forEach((element) => {
+        /**
+         * Bolt Optimization:
+         * - What: Replace Set.prototype.forEach with a for...of loop.
+         * - Why: getIndexFromObserver is called frequently on scroll. Using .forEach allocates a new callback function on every call, increasing memory churn.
+         * - Impact: Eliminates function allocation overhead in a hot path, reducing GC pressure.
+         */
+        for (const element of visibleBlocks) {
             const index = blocks.indexOf(element);
             if (index > bestIndex) {
                 bestIndex = index;
             }
-        });
+        }
         return bestIndex;
     }
 


### PR DESCRIPTION
💡 What: Replaced `.forEach()` with traditional `for` and `for...of` loops in `IntersectionObserver` callbacks and scroll handlers in `js/block-navigation.js`.
🎯 Why: `.forEach()` allocates a new callback function closure on every invocation. When executed in high-frequency events like scrolling, this creates unnecessary memory churn and garbage collection overhead.
📊 Impact: Eliminates function allocation overhead during scroll events, slightly reducing main thread GC pressure.
🔬 Measurement: Check the memory profiler during rapid scrolling to confirm reduced allocation rates.

---
*PR created automatically by Jules for task [4118721707389519433](https://jules.google.com/task/4118721707389519433) started by @ryusoh*