### PR TITLE
test: add coverage for imageFallback, block-navigation, page-transition

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -108,3 +108,13 @@
 **Learning:** When writing navigation or click interception unit tests in JSDOM, `window.location.href` defaults to `http://localhost/`. Tests using external URLs (e.g., `https://example.com/test`) will falsely trigger cross-origin/same-origin validation barriers. Furthermore, tests spanning across modules with multiple internal references (`isAtTopOrBottom`, `getCurrentIndex`) must carefully sync or mock DOM layouts (`scrollHeight`, `scrollTop`) to accurately evaluate internally scoped closures without forcibly modifying feature code to expose them.
 
 **Action:** Standardize same-origin test URL configurations across the suite by applying `Object.defineProperty` on `window.location` consistently, or use `http://localhost/test` paths. Prevent modifying `.js` feature files to expose properties purely for coverage purposes, and instead mock the environment to invoke internal calls via public event handlers.
+
+## 2026-06-06 - VM Sandbox Timer Mocking
+
+**Learning:** When testing code executed inside a `vm` sandbox (`runInContext`) that utilizes timers, `jest.useFakeTimers()` will not automatically affect the sandbox's native `setTimeout`.
+**Action:** You must explicitly map the sandbox's timers to the global environment (e.g., `context.setTimeout = global.setTimeout`) for Jest's timer mocks (like `jest.advanceTimersByTime`) to work correctly.
+
+## 2026-06-06 - ES2019 Optional Catch Binding for ESLint
+
+**Learning:** When writing try-catch blocks where the caught error object is unused, ESLint will fail with `no-unused-vars` if the error variable is explicitly captured.
+**Action:** Use ES2019 optional catch binding (e.g., `catch { /* ignore */ }`) instead of explicitly capturing the error variable (e.g., `catch (e)`) to prevent ESLint failures.

--- a/tests/js/block-navigation.test.js
+++ b/tests/js/block-navigation.test.js
@@ -595,6 +595,80 @@ describe('js/block-navigation.js', () => {
         });
     });
 
+    describe('debounce window and RAF checks directly', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+            jest.restoreAllMocks();
+        });
+
+        test('should execute fn directly via setTimeout if window is mocked to simulate undefined', () => {
+            const debounce = testing.debounce;
+
+            const originalRaf = context.window.requestAnimationFrame;
+            context.window.requestAnimationFrame = undefined;
+
+            const originalSetTimeout = context.setTimeout;
+            const originalClearTimeout = context.clearTimeout;
+
+            context.setTimeout = global.setTimeout;
+            context.clearTimeout = global.clearTimeout;
+
+            const func = jest.fn();
+            const debounced = debounce(func, 100);
+
+            debounced();
+            expect(func).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(100);
+
+            expect(func).toHaveBeenCalledTimes(1);
+
+            context.window.requestAnimationFrame = originalRaf;
+            context.setTimeout = originalSetTimeout;
+            context.clearTimeout = originalClearTimeout;
+        });
+
+        test('should cancel pending RAF if debounce is called again', () => {
+            const debounce = testing.debounce;
+            const mockCaf = jest.fn();
+            const mockRaf = jest.fn().mockReturnValue(12345);
+
+            const originalRaf = context.window.requestAnimationFrame;
+            const originalCaf = context.window.cancelAnimationFrame;
+
+            context.window.requestAnimationFrame = mockRaf;
+            context.window.cancelAnimationFrame = mockCaf;
+
+            const originalSetTimeout = context.setTimeout;
+            const originalClearTimeout = context.clearTimeout;
+
+            context.setTimeout = global.setTimeout;
+            context.clearTimeout = global.clearTimeout;
+
+            const func = jest.fn();
+            const debounced = debounce(func, 100);
+
+            debounced();
+            jest.advanceTimersByTime(100);
+
+            expect(mockRaf).toHaveBeenCalledTimes(1);
+            expect(mockCaf).not.toHaveBeenCalled();
+
+            debounced();
+
+            expect(mockCaf).toHaveBeenCalledWith(12345);
+
+            context.window.requestAnimationFrame = originalRaf;
+            context.window.cancelAnimationFrame = originalCaf;
+            context.setTimeout = originalSetTimeout;
+            context.clearTimeout = originalClearTimeout;
+        });
+    });
+
     describe('logWarning', () => {
         let originalConsole;
         beforeEach(() => {

--- a/tests/js/loader/imageFallback.test.js
+++ b/tests/js/loader/imageFallback.test.js
@@ -154,7 +154,7 @@ describe('imageFallback.js', () => {
         window.console.warn = originalWarn;
     });
 
-    test('covers querySelectorAll loop line 57', () => {
+    test('should initialize fallbacks for all image tags on load', () => {
         jest.resetModules();
         document.body.innerHTML =
             '<img data-fallbacks=\'["a.jpg"]\' /><img data-fallbacks=\'["b.jpg"]\' />';
@@ -163,7 +163,7 @@ describe('imageFallback.js', () => {
         expect(imgs[0].getAttribute('data-fallbacks')).toBe('["a.jpg"]');
     });
 
-    test('covers exception block with console undefined', () => {
+    test('should gracefully ignore initialization errors and not crash the application', () => {
         jest.resetModules();
         const origQuerySelectorAll = document.querySelectorAll;
         document.querySelectorAll = () => {
@@ -200,5 +200,131 @@ describe('imageFallback.js', () => {
                 vm.runInContext(code, context);
             }).not.toThrow();
         });
+    });
+
+    it('should add "is-fallback-ready" class when global load event fires for valid image (branch coverage)', () => {
+        const img = document.createElement('img');
+        img.setAttribute('data-fallbacks', '["url1.png"]');
+        document.body.appendChild(img);
+        const loadEvent = new Event('load', { bubbles: true });
+        img.dispatchEvent(loadEvent);
+        expect(img.classList.contains('is-fallback-ready')).toBe(true);
+    });
+
+    it('should not throw if target is missing in load event', () => {
+        const loadEvent = new Event('load', { bubbles: true });
+        Object.defineProperty(loadEvent, 'target', { value: null });
+        document.dispatchEvent(loadEvent);
+    });
+
+    it('should not throw if target is missing in error event', () => {
+        const errEvent = new Event('error', { bubbles: true });
+        Object.defineProperty(errEvent, 'target', { value: null });
+        document.dispatchEvent(errEvent);
+    });
+
+    it('should not throw if target is not IMG in error event', () => {
+        const errEvent = new Event('error', { bubbles: true });
+        const div = document.createElement('div');
+        div.dispatchEvent(errEvent);
+    });
+
+    it('should not throw if error event target has no fallback list', () => {
+        const errEvent = new Event('error', { bubbles: true });
+        const img = document.createElement('img');
+        img.setAttribute('data-fallbacks', '["a"]');
+        img.dispatchEvent(errEvent);
+    });
+
+    it('should return null from sanitizeFallbackList if array contains no valid strings', () => {
+        const img = document.createElement('img');
+        img.setAttribute('data-fallbacks', '[1, 2, null]');
+        imageFallback.initFallback(img);
+        expect(img.src).toBe('');
+    });
+
+    it('should not mark fallback as ready if image src matches but is not complete', () => {
+        const img = document.createElement('img');
+        img.src = 'url1.png';
+        img.setAttribute('data-fallbacks', '["url1.png"]');
+        Object.defineProperty(img, 'complete', { value: false });
+
+        imageFallback.initFallback(img);
+        expect(img.classList.contains('is-fallback-ready')).toBe(false);
+    });
+
+    test('should not mark fallback as ready if complete but naturalWidth is 0', () => {
+        const img = document.createElement('img');
+        img.src = 'url1.png';
+        img.setAttribute('data-fallbacks', '["url1.png"]');
+        Object.defineProperty(img, 'complete', { value: true });
+        Object.defineProperty(img, 'naturalWidth', { value: 0 });
+
+        imageFallback.initFallback(img);
+        expect(img.classList.contains('is-fallback-ready')).toBe(false);
+    });
+
+    test('should update image source if src exists but does not match first fallback', () => {
+        const img = document.createElement('img');
+        img.src = 'other.png';
+        img.setAttribute('data-fallbacks', '["url1.png"]');
+
+        imageFallback.initFallback(img);
+        expect(img.src).toContain('url1.png');
+    });
+
+    test('should export functions correctly in module environment', () => {
+        // Evaluate in a context where window is missing but module.exports is present
+        const exportsObj = {};
+        const sandbox = {
+            document: global.document,
+            module: { exports: exportsObj },
+        };
+        const vm = require('vm');
+        vm.createContext(sandbox);
+        const code = require('fs').readFileSync('js/loader/imageFallback.js', 'utf8');
+        vm.runInContext(code, sandbox);
+
+        expect(sandbox.module.exports.parseFallbacks).toBeDefined();
+    });
+
+    test('should not export if module is present without exports', () => {
+        const sandbox = {
+            window: { console: global.console },
+            document: global.document,
+            module: {},
+        };
+        const vm = require('vm');
+        vm.createContext(sandbox);
+        const code = require('fs').readFileSync('js/loader/imageFallback.js', 'utf8');
+        vm.runInContext(code, sandbox);
+
+        expect(sandbox.module.exports).toBeUndefined();
+    });
+
+    test('should export to window if module is explicitly undefined', () => {
+        const sandbox = {
+            window: { console: global.console },
+            document: global.document,
+            // module is explicitly undefined
+        };
+        const vm = require('vm');
+        vm.createContext(sandbox);
+        const code = require('fs').readFileSync('js/loader/imageFallback.js', 'utf8');
+        vm.runInContext(code, sandbox);
+
+        expect(sandbox.window.__ImageFallbackForTesting).toBeDefined();
+    });
+
+    test('should run cleanly without side effects when evaluated in window-less environment', () => {
+        const sandbox = {
+            document: global.document,
+            module: { exports: {} },
+        };
+        const vm = require('vm');
+        vm.createContext(sandbox);
+        const code = require('fs').readFileSync('js/loader/imageFallback.js', 'utf8');
+        vm.runInContext(code, sandbox);
+        expect(sandbox.module.exports).toBeDefined();
     });
 });

--- a/tests/js/page-transition.test.js
+++ b/tests/js/page-transition.test.js
@@ -707,6 +707,14 @@ describe('page-transition.js', () => {
     });
 
     describe('Global click and pageshow event handlers', () => {
+        beforeAll(() => {
+            // Ensure location is valid for click tests to prevent cross origin block
+            try {
+                window.history.pushState({}, 'Test Title', 'http://localhost/');
+            } catch {
+                /* ignore */
+            }
+        });
         let originalMatchMedia;
         let documentClickListeners = [];
         let documentPageShowListeners = [];
@@ -894,6 +902,56 @@ describe('page-transition.js', () => {
             activeClickListener(clickEvent);
 
             expect(clickEvent.defaultPrevented).toBe(true);
+        });
+
+        it('should exit early and not navigate when click event default is prevented', () => {
+            const assignSpy = jest.fn();
+            Object.defineProperty(window, 'location', {
+                value: { assign: assignSpy, origin: 'http://localhost', href: 'http://localhost/' },
+                writable: true,
+                configurable: true,
+            });
+            document.body.innerHTML =
+                '<a href="http://localhost/dest" data-page-transition id="valid-link">Link</a>';
+            const anchor = document.getElementById('valid-link');
+
+            const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+            Object.defineProperty(event, 'defaultPrevented', { value: true });
+
+            anchor.dispatchEvent(event);
+            expect(assignSpy).not.toHaveBeenCalled();
+        });
+
+        it('should exit early and not navigate for non-primary mouse button clicks', () => {
+            const assignSpy = jest.fn();
+            Object.defineProperty(window, 'location', {
+                value: { assign: assignSpy, origin: 'http://localhost', href: 'http://localhost/' },
+                writable: true,
+                configurable: true,
+            });
+            document.body.innerHTML =
+                '<a href="http://localhost/dest" data-page-transition id="valid-link">Link</a>';
+            const anchor = document.getElementById('valid-link');
+
+            const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 1 });
+            anchor.dispatchEvent(event);
+            expect(assignSpy).not.toHaveBeenCalled();
+        });
+
+        it('should exit early and not navigate if anchor has a skip nav class', () => {
+            const assignSpy = jest.fn();
+            Object.defineProperty(window, 'location', {
+                value: { assign: assignSpy, origin: 'http://localhost', href: 'http://localhost/' },
+                writable: true,
+                configurable: true,
+            });
+            document.body.innerHTML =
+                '<a href="http://localhost/dest" data-page-transition class="nav-back" id="valid-link">Link</a>';
+            const anchor = document.getElementById('valid-link');
+
+            const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+            anchor.dispatchEvent(event);
+            expect(assignSpy).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Added robust unit tests to cover missing execution paths in three utility files:
- `page-transition.js`: Covered `isValidTransitionClick` edge cases by implicitly validating defaultPrevented, non-standard mouse events, and `nav-back` overrides through the global click listener.
- `block-navigation.js`: Mocked `setTimeout` and `requestAnimationFrame` context timers to correctly test `debounce` fallback implementations across simulated DOM environments.
- `imageFallback.js`: Addressed branch testing for missing network event targets, empty parsed datasets, and module export behavior when evaluated within raw `vm` contexts.

Verified functional parity via full regression suite and ensured test configurations comply with zero-modification policies for core application logic.

---
*PR created automatically by Jules for task [13358995922226714685](https://jules.google.com/task/13358995922226714685) started by @ryusoh*