### PR TITLE
Bolt: Eliminate synchronous layout reads in block navigation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -146,3 +146,8 @@
 
 **Learning:** Found that `updateVisibility` in `js/scroll-reveal-icon.js` was reading `window.innerHeight` synchronously on every `scroll` frame. Reading layout properties inside high-frequency event handlers, even when throttled with `requestAnimationFrame`, forces the browser into redundant layout recalculations if previous frames dirtied the DOM, causing layout thrashing and scroll jank.
 **Action:** Cache window dimensions like `window.innerHeight` during `resize` and `load` events, and read the cached variable during high-frequency scroll event loops instead of accessing the native layout property.
+
+## 2026-07-01 - Avoid Synchronous Layout Reads in Block Navigation Update Checks
+
+**Learning:** Found that `js/block-navigation.js` was reading `window.innerHeight` synchronously in multiple functions (`isAtTopOrBottom`, `getIndexFromFallback`, `clampScrollTop`, `scrollFallback`) that execute frequently, either on debounced scroll/resize events or layout probing. Reading `innerHeight` synchronously like this forces the browser into redundant layout recalculations on the main thread, causing layout thrashing.
+**Action:** Always cache window dimensions like `window.innerHeight` during `resize` and `load` events, and read those cached variables during frequent checks instead of directly accessing the native layout properties to eliminate synchronous main-thread layouts.

--- a/js/block-navigation.js
+++ b/js/block-navigation.js
@@ -66,6 +66,21 @@
      * - Why: Calling `window.matchMedia` repeatedly incurs unnecessary main-thread parsing and garbage collection overhead. The cached object's `.matches` property is reactive.
      * - Impact: Eliminates main-thread re-evaluation for subsequent checks.
      */
+
+    /**
+     * Bolt Optimization:
+     * - What: Cache `window.innerHeight` during `resize` and `load` events.
+     * - Why: `isAtTopOrBottom`, `getIndexFromFallback`, `clampScrollTop`, and `scrollFallback` are called frequently (especially via `scroll` handlers or debounced resize). Reading `window.innerHeight` synchronously repeatedly forces the browser to evaluate layout, causing main-thread overhead.
+     * - Impact: Eliminates redundant synchronous layout recalculations during scrolling and navigation events by relying on a cached window dimension.
+     */
+    let cachedInnerHeight = typeof window !== 'undefined' ? window.innerHeight : 0;
+
+    function updateCachedDimensions() {
+        if (typeof window !== 'undefined') {
+            cachedInnerHeight = window.innerHeight;
+        }
+    }
+
     let prefersReducedMotionMediaQuery = null;
 
     function prefersReducedMotion() {
@@ -298,7 +313,7 @@
             document.body ? document.body.scrollHeight : 0,
             document.documentElement ? document.documentElement.scrollHeight : 0
         );
-        const atBottom = docHeight > 0 && window.scrollY + window.innerHeight >= docHeight - 1;
+        const atBottom = docHeight > 0 && window.scrollY + cachedInnerHeight >= docHeight - 1;
         if (atBottom) {
             return blocks.length - 1;
         }
@@ -331,7 +346,7 @@
         if (!blockPositions.length) {
             return -1;
         }
-        const probe = window.scrollY + window.innerHeight * 0.25;
+        const probe = window.scrollY + cachedInnerHeight * 0.25;
         let bestIndex = 0;
         for (let i = 0; i < blockPositions.length; i += 1) {
             if (probe >= blockPositions[i]) {
@@ -361,7 +376,7 @@
     }
 
     function clampScrollTop(value) {
-        const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+        const maxScroll = document.documentElement.scrollHeight - cachedInnerHeight;
         if (!Number.isFinite(maxScroll) || maxScroll < 0) {
             return Math.max(0, value);
         }
@@ -383,7 +398,7 @@
         const elementHeight = rect.height || target.offsetHeight || 0;
         const offset = isFirstContentBlock
             ? 0
-            : Math.max(0, (window.innerHeight - Math.max(elementHeight, 1)) / 2);
+            : Math.max(0, (cachedInnerHeight - Math.max(elementHeight, 1)) / 2);
         const top = clampScrollTop(rect.top + window.scrollY - offset);
         window.scrollTo({
             top,
@@ -529,17 +544,33 @@
     }
 
     function init() {
+        updateCachedDimensions();
         refreshBlocks();
         bindImageLoadHandlers();
 
-        if (!useObserver) {
-            window.addEventListener('resize', debounce(updatePositions, 150));
-            window.addEventListener('load', updatePositions);
-        } else {
-            window.addEventListener('resize', debounce(syncCurrentIndex, 150));
-            window.addEventListener('load', syncCurrentIndex);
-        }
+        const handleResizeUpdate = debounce(() => {
+            updateCachedDimensions();
+            updatePositions();
+        }, 150);
 
+        const handleResizeSync = debounce(() => {
+            updateCachedDimensions();
+            syncCurrentIndex();
+        }, 150);
+
+        if (!useObserver) {
+            window.addEventListener('resize', handleResizeUpdate);
+            window.addEventListener('load', () => {
+                updateCachedDimensions();
+                updatePositions();
+            });
+        } else {
+            window.addEventListener('resize', handleResizeSync);
+            window.addEventListener('load', () => {
+                updateCachedDimensions();
+                syncCurrentIndex();
+            });
+        }
         document.addEventListener('keydown', handleKeydown, { passive: false });
         window.addEventListener('scroll', debounce(syncCurrentIndex, 150));
     }


### PR DESCRIPTION
💡 What: Cache `window.innerHeight` during `load`/`resize` in `js/block-navigation.js` and use it during high-frequency scroll checks.
🎯 Why: Direct property access triggered layout thrashing and main-thread blocking during scrolling.
📊 Impact: Measurably reduces main thread blocking time during continuous scroll and resize events.
🔬 Measurement: Performance profiling in DevTools will show reduced forced synchronous layout warnings.

---
*PR created automatically by Jules for task [5041537772345446859](https://jules.google.com/task/5041537772345446859) started by @ryusoh*