### PR TITLE
chore: code health and cleanup

### DIFF
--- a/tests/js/block-navigation.test.js
+++ b/tests/js/block-navigation.test.js
@@ -907,31 +907,31 @@ describe('coverage helper', () => {
                 const t = window.__BlockNavigationForTesting;
                 try {
                     t.clampScrollTop(-10);
-                } catch {}
+                } catch { /* ignore error during coverage check */ }
                 try {
                     t.isEditableActive();
-                } catch {}
+                } catch { /* ignore error during coverage check */ }
                 try {
                     t.shouldUseElement(document.body);
-                } catch {}
+                } catch { /* ignore error during coverage check */ }
                 try {
                     t.handleEscapeKey({ preventDefault: () => {} });
-                } catch {}
+                } catch { /* ignore error during coverage check */ }
                 try {
                     t.debounce(() => {}, 10)();
-                } catch {}
+                } catch { /* ignore error during coverage check */ }
                 try {
                     t.getIndexFromFallback();
-                } catch {}
+                } catch { /* ignore error during coverage check */ }
                 try {
                     t.calculateNextIndex('ArrowDown');
-                } catch {}
+                } catch { /* ignore error during coverage check */ }
                 try {
                     t.scrollToIndex(0);
-                } catch {}
+                } catch { /* ignore error during coverage check */ }
                 try {
                     t.performScroll(document.body, true, 'smooth', true);
-                } catch {}
+                } catch { /* ignore error during coverage check */ }
 
                 // Trigger events
                 if (loadCb) {

--- a/tests/js/block-navigation.test.js
+++ b/tests/js/block-navigation.test.js
@@ -907,31 +907,49 @@ describe('coverage helper', () => {
                 const t = window.__BlockNavigationForTesting;
                 try {
                     t.clampScrollTop(-10);
-                } catch { /* ignore error during coverage check */ }
+                } catch {
+                    /* ignore error during coverage check */
+                }
                 try {
                     t.isEditableActive();
-                } catch { /* ignore error during coverage check */ }
+                } catch {
+                    /* ignore error during coverage check */
+                }
                 try {
                     t.shouldUseElement(document.body);
-                } catch { /* ignore error during coverage check */ }
+                } catch {
+                    /* ignore error during coverage check */
+                }
                 try {
                     t.handleEscapeKey({ preventDefault: () => {} });
-                } catch { /* ignore error during coverage check */ }
+                } catch {
+                    /* ignore error during coverage check */
+                }
                 try {
                     t.debounce(() => {}, 10)();
-                } catch { /* ignore error during coverage check */ }
+                } catch {
+                    /* ignore error during coverage check */
+                }
                 try {
                     t.getIndexFromFallback();
-                } catch { /* ignore error during coverage check */ }
+                } catch {
+                    /* ignore error during coverage check */
+                }
                 try {
                     t.calculateNextIndex('ArrowDown');
-                } catch { /* ignore error during coverage check */ }
+                } catch {
+                    /* ignore error during coverage check */
+                }
                 try {
                     t.scrollToIndex(0);
-                } catch { /* ignore error during coverage check */ }
+                } catch {
+                    /* ignore error during coverage check */
+                }
                 try {
                     t.performScroll(document.body, true, 'smooth', true);
-                } catch { /* ignore error during coverage check */ }
+                } catch {
+                    /* ignore error during coverage check */
+                }
 
                 // Trigger events
                 if (loadCb) {


### PR DESCRIPTION
## What
Fixed empty catch blocks in `tests/js/block-navigation.test.js`. Verified structural complexity and ensured no dead code or unhandled exceptions remained in main code.

## Why
Empty catch blocks trigger linting rules and could mask silent errors during testing. This explicitly adds comments to clarify intent. The previous pass had already ensured modularity (complexity <= 10) and dead code pruning were addressed.

## Impact
Test suite is cleaner and conforms to linting rules. Structural complexity remains within limits.

## Measurement
Ran `pnpm lint` and `pnpm test` with 100% pass rate.

---
*PR created automatically by Jules for task [11927952052022199091](https://jules.google.com/task/11927952052022199091) started by @ryusoh*