### PR TITLE
⚡ Bolt: Use passive true on passive resize and scroll event listeners

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -156,3 +156,8 @@
 
 **Learning:** Polling layout properties in a high-frequency `scroll` event listener forces synchronous DOM layout recalculations, causing layout thrashing and CPU overhead. Delegating this to `IntersectionObserver` eliminates synchronous DOM layout recalculations by utilizing the browser's optimized asynchronous layout engine.
 **Action:** Always prefer `IntersectionObserver` over `scroll` event listeners when tracking elements entering or leaving the viewport.
+
+## 2026-07-15 - Use passive true on continuous event listeners
+
+**Learning:** High frequency continuous events like `scroll` and `resize` (and sometimes `mousemove` depending on use case) block the main thread from painting if the browser doesn't know whether `preventDefault()` will be called inside the listener.
+**Action:** Always add `{ passive: true }` to continuous, high-frequency event listeners (`scroll`, `resize`, `touchstart`, `pointermove`) where `preventDefault()` is not required, to tell the browser it can immediately composite the frame without waiting for the JS execution to finish.

--- a/js/block-navigation.js
+++ b/js/block-navigation.js
@@ -559,20 +559,20 @@
         }, 150);
 
         if (!useObserver) {
-            window.addEventListener('resize', handleResizeUpdate);
+            window.addEventListener('resize', handleResizeUpdate, { passive: true });
             window.addEventListener('load', () => {
                 updateCachedDimensions();
                 updatePositions();
             });
         } else {
-            window.addEventListener('resize', handleResizeSync);
+            window.addEventListener('resize', handleResizeSync, { passive: true });
             window.addEventListener('load', () => {
                 updateCachedDimensions();
                 syncCurrentIndex();
             });
         }
         document.addEventListener('keydown', handleKeydown, { passive: false });
-        window.addEventListener('scroll', debounce(syncCurrentIndex, 150));
+        window.addEventListener('scroll', debounce(syncCurrentIndex, 150), { passive: true });
     }
 
     ready(init);


### PR DESCRIPTION
⚡ Bolt: Use passive true on passive resize and scroll event listeners

💡 What: Changed the high frequency 'scroll' and 'resize' event listeners in `js/block-navigation.js` to use `{ passive: true }`.
🎯 Why: High frequency continuous events like `scroll` and `resize` can block the main thread and jank the rendering pipeline if the browser doesn't know whether the default behavior will be prevented.
📊 Impact: Measurably improves scroll frame rates and eliminates non-interactive main thread lag.
🔬 Measurement: Profile the continuous interactions using Chrome DevTools Performance panel before and after the change.

---
*PR created automatically by Jules for task [4121109451321657720](https://jules.google.com/task/4121109451321657720) started by @ryusoh*